### PR TITLE
Unstake only active validators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, feat/*]
 
 jobs:
   build:

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -200,10 +200,12 @@ contract StakeManager is
 
     // Housekeeping function. @todo remove later
     function forceUnstake(uint256 validatorId) external onlyGovernance {
+        require(validators[validatorId].deactivationEpoch == 0);
         _unstake(validatorId, currentEpoch, false);
     }
 
     function forceUnstakePOL(uint256 validatorId) external onlyGovernance {
+        require(validators[validatorId].deactivationEpoch == 0);
         _unstake(validatorId, currentEpoch, true);
     }
 

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -421,14 +421,14 @@ contract StakeManager is
     }
 
     function unstake(uint256 validatorId) external onlyStaker(validatorId) {
-        _unstake(validatorId, false);
+        _unstakeValidator(validatorId, false);
     }
 
     function unstakePOL(uint256 validatorId) external onlyStaker(validatorId) {
-        _unstake(validatorId, true);
+        _unstakeValidator(validatorId, true);
     }
 
-    function _unstake(uint256 validatorId, bool pol) internal {
+    function _unstakeValidator(uint256 validatorId, bool pol) internal {
         require(validatorAuction[validatorId].amount == 0);
 
         Status status = validators[validatorId].status;

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -200,12 +200,10 @@ contract StakeManager is
 
     // Housekeeping function. @todo remove later
     function forceUnstake(uint256 validatorId) external onlyGovernance {
-        require(validators[validatorId].deactivationEpoch == 0);
         _unstake(validatorId, currentEpoch, false);
     }
 
     function forceUnstakePOL(uint256 validatorId) external onlyGovernance {
-        require(validators[validatorId].deactivationEpoch == 0);
         _unstake(validatorId, currentEpoch, true);
     }
 
@@ -1114,6 +1112,7 @@ contract StakeManager is
     }
 
     function _unstake(uint256 validatorId, uint256 exitEpoch, bool pol) internal {
+        require(validators[validatorId].deactivationEpoch == 0);
         // TODO: if validators unstake and slashed to 0, he will be forced to unstake again
         // must think how to handle it correctly
         _updateRewards(validatorId);

--- a/test/units/staking/stakeManager/StakeManager.Staking.js
+++ b/test/units/staking/stakeManager/StakeManager.Staking.js
@@ -444,7 +444,7 @@ describe('unstake', function () {
       // mock for i ... range(delay) checkPoint()
       await this.governance.update(
         this.stakeManager.address,
-        this.stakeManager.interface.encodeFunctionData('setCurrentEpoch', [endEpoch])
+        this.stakeManager.interface.encodeFunctionData('setCurrentEpoch', [endEpoch + 1])
       )
 
       await this.stakeManager


### PR DESCRIPTION
Currently, the `_unstake(validatorId, exitEpoch, rewardInPol)` method lacks a validation check on previously offboarded validators in case they have not unstaked their claim. (when they have, their validatorNFT is [burned](https://github.com/0xPolygon/pos-contracts/blob/feat/pol/contracts/staking/stakeManager/StakeManager.sol#L512) and hence the function reverts on the `ownerOf` lookup [here](https://github.com/0xPolygon/pos-contracts/blob/feat/pol/contracts/staking/stakeManager/StakeManager.sol#L1120))
This check is validated externally on all invocations of the method except for the `forceUnstake` method.