### PR TITLE
fix: avoid failure when calling `depositManager.updateChildChainAndStateSender()`

### DIFF
--- a/scripts/deployment-scripts/syncChildStateToRoot.s.sol
+++ b/scripts/deployment-scripts/syncChildStateToRoot.s.sol
@@ -48,11 +48,11 @@ contract SyncChildStateToRootScript is Script {
     StateSender stateSenderContract = StateSender(vm.parseJsonAddress(json, '.root.StateSender'));
     stateSenderContract.register(vm.parseJsonAddress(json, '.root.DepositManagerProxy'), vm.parseJsonAddress(json, '.child.ChildChain'));
 
-    address currentChildChain = registry.childChain();
-    address currentStateSender = registry.stateSender();
+    DepositManager depositManager = DepositManager(payable(vm.parseJsonAddress(json, '.root.DepositManagerProxy')));
+    address currentChildChain = depositManager.childChain();
+    address currentStateSender = depositManager.stateSender();
     (address newChildChain, address newStateSender) = registry.getChildChainAndStateSender();
     if (currentChildChain != newChildChain || currentStateSender != newStateSender) {
-      DepositManager depositManager = DepositManager(payable(vm.parseJsonAddress(json, '.root.DepositManagerProxy')));
       depositManager.updateChildChainAndStateSender();
     }
 

--- a/scripts/deployment-scripts/syncChildStateToRoot.s.sol
+++ b/scripts/deployment-scripts/syncChildStateToRoot.s.sol
@@ -13,7 +13,7 @@ import {DepositManager} from "../helpers/interfaces/DepositManager.generated.sol
 contract SyncChildStateToRootScript is Script {
   function run() public {
 
-    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY"); 
+    uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
 
     vm.startBroadcast(deployerPrivateKey);
     string memory path = "contractAddresses.json";
@@ -44,15 +44,18 @@ contract SyncChildStateToRootScript is Script {
 
     bytes memory childChainData = abi.encodeWithSelector(bytes4(keccak256("updateContractMap(bytes32,address)")), keccak256(abi.encodePacked("childChain")), vm.parseJsonAddress(json, '.child.ChildChain'));
     governance.update(registryAddress, childChainData);
-    
-    
-    
+
     StateSender stateSenderContract = StateSender(vm.parseJsonAddress(json, '.root.StateSender'));
     stateSenderContract.register(vm.parseJsonAddress(json, '.root.DepositManagerProxy'), vm.parseJsonAddress(json, '.child.ChildChain'));
-    DepositManager depositManager = DepositManager(payable(vm.parseJsonAddress(json, '.root.DepositManagerProxy')));
-    depositManager.updateChildChainAndStateSender();
+
+    address currentChildChain = registry.childChain();
+    address currentStateSender = registry.stateSender();
+    (address newChildChain, address newStateSender) = registry.getChildChainAndStateSender();
+    if (currentChildChain != newChildChain || currentStateSender != newStateSender) {
+      DepositManager depositManager = DepositManager(payable(vm.parseJsonAddress(json, '.root.DepositManagerProxy')));
+      depositManager.updateChildChainAndStateSender();
+    }
 
     vm.stopBroadcast();
-    
   }
 }

--- a/scripts/matic-cli-scripts/stake.s.sol
+++ b/scripts/matic-cli-scripts/stake.s.sol
@@ -47,7 +47,11 @@ contract MaticStake is Script {
     
     console.log("Validator set size : ", stakeManager.currentValidatorSetSize());
 
-    // stakeManager.stakeForPOL(validatorAccount, stakeAmount, heimdallFee, true, pubkey);
+
+    stakeManager.stakeForPOL(validatorAccount, stakeAmount, heimdallFee, true, pubkey);
+
+
+
   }
 
   function topUpForFee() public {

--- a/scripts/matic-cli-scripts/stake.s.sol
+++ b/scripts/matic-cli-scripts/stake.s.sol
@@ -47,11 +47,7 @@ contract MaticStake is Script {
     
     console.log("Validator set size : ", stakeManager.currentValidatorSetSize());
 
-
-    stakeManager.stakeForPOL(validatorAccount, stakeAmount, heimdallFee, true, pubkey);
-
-
-
+    // stakeManager.stakeForPOL(validatorAccount, stakeAmount, heimdallFee, true, pubkey);
   }
 
   function topUpForFee() public {


### PR DESCRIPTION
Make sure at least one of the addresses changed before making the call.

In [kurtosis-polygon-pos](https://github.com/0xPolygon/kurtosis-polygon-pos), we have a [workflow](https://github.com/0xPolygon/kurtosis-polygon-pos/blob/main/.github/workflows/deploy.yaml#L280) that will deploy the package twice (and therefore deploy the L2 contracts a [first](https://github.com/0xPolygon/kurtosis-polygon-pos/blob/main/.github/workflows/deploy.yaml#L311) time and a [second](https://github.com/0xPolygon/kurtosis-polygon-pos/blob/main/.github/workflows/deploy.yaml#L335) time), but it will fail on the second deployment. When calling the 
`syncChildStateToRoot.s.sol` function, it will attempt to update the child chain and state sender addresses even though the addresses have not changed, causing a revert.

```bash
+ echo 'Mapping L2 contracts to the registry on L1...'
Mapping L2 contracts to the registry on L1...
+ forge script --rpc-url http://el-1-geth-lighthouse:8545 --broadcast scripts/deployment-scripts/syncChildStateToRoot.s.sol:SyncChildStateToRootScript
Compiling 3 files with Solc 0.8.28
Solc 0.8.28 finished in 874.06ms
Compiler run successful with warnings:
Warning (3628): This contract has a payable fallback function, but no receive ether function. Consider adding a receive ether function.
 --> scripts/helpers/interfaces/DepositManager.generated.sol:4:1:
  |
4 | interface DepositManager {
  | ^ (Relevant source part starts here and spans across multiple lines).
Note: The payable fallback function is defined here.
 --> scripts/helpers/interfaces/DepositManager.generated.sol:9:5:
  |
9 |     fallback() external payable;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Warning (2072): Unused local variable.
  --> scripts/deployment-scripts/syncChildStateToRoot.s.sol:26:5:
   |
26 |     Registry registry = Registry(registryAddress);
   |     ^^^^^^^^^^^^^^^^^

Traces:
  [889232] → new SyncChildStateToRootScript@0x9f7cF1d1F558E57ef88a59ac3D47214eF25B6A06
    └─ ← [Return] 4331 bytes of code

  [1987299] SyncChildStateToRootScript::run()
    ├─ [0] VM::envUint("DEPLOYER_PRIVATE_KEY") [staticcall]
    │   └─ ← [Return] <env var value>
    ├─ [0] VM::startBroadcast(<pk>)
    │   └─ ← [Return] 
    ├─ [0] VM::readFile("contractAddresses.json") [staticcall]
    │   └─ ← [Return] <file>
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".root.Registry") [staticcall]
    │   └─ ← [Return] 0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".root.GovernanceProxy") [staticcall]
    │   └─ ← [Return] 0x6a19d7A5399D043874280Ce4B8C95612cA7A9B81
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".root.tokens.MaticWeth") [staticcall]
    │   └─ ← [Return] 0x0F8877706016BE7F8EE5c2E3D47C89BA3A4DcC44
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".child.tokens.MaticWeth") [staticcall]
    │   └─ ← [Return] 0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F
    ├─ [497186] 0x6a19d7A5399D043874280Ce4B8C95612cA7A9B81::update(0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, 0xe117694b0000000000000000000000000f8877706016be7f8ee5c2e3d47c89ba3a4dcc440000000000000000000000002511f0c8254bf0b3d08aaf56340d0731e7f9e22f0000000000000000000000000000000000000000000000000000000000000000)
    │   ├─ [492026] 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331::update(0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, 0xe117694b0000000000000000000000000f8877706016be7f8ee5c2e3d47c89ba3a4dcc440000000000000000000000002511f0c8254bf0b3d08aaf56340d0731e7f9e22f0000000000000000000000000000000000000000000000000000000000000000) [delegatecall]
    │   │   ├─ [486120] 0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F::mapToken(0x0F8877706016BE7F8EE5c2E3D47C89BA3A4DcC44, 0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, false)
    │   │   │   ├─ [469908] 0x32Ac76FdbF38b50D584DD943daCDA4b07FdcBFC7::createExitQueue(0x0F8877706016BE7F8EE5c2E3D47C89BA3A4DcC44)
    │   │   │   │   ├─ [464751] 0xADb789e75A0BED665aCbe9fd939c4FCBa8e05410::createExitQueue(0x0F8877706016BE7F8EE5c2E3D47C89BA3A4DcC44) [delegatecall]
    │   │   │   │   │   ├─ [424598] → new PriorityQueue@0xdB9FE3B1fDE2f9f8DA615CA87D4599fa04990363
    │   │   │   │   │   │   ├─ emit OwnershipTransferred(previousOwner: 0x0000000000000000000000000000000000000000, newOwner: 0x32Ac76FdbF38b50D584DD943daCDA4b07FdcBFC7)
    │   │   │   │   │   │   └─ ← [Return] 1879 bytes of code
    │   │   │   │   │   └─ ← [Stop] 
    │   │   │   │   └─ ← [Return] 
    │   │   │   ├─ emit TokenMapped(rootToken: 0x0F8877706016BE7F8EE5c2E3D47C89BA3A4DcC44, childToken: 0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F)
    │   │   │   └─ ← [Stop] 
    │   │   └─ ← [Stop] 
    │   └─ ← [Return] 
    ├─ [0] console::log("Success!") [staticcall]
    │   └─ ← [Stop] 
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".root.tokens.MaticToken") [staticcall]
    │   └─ ← [Return] 0x8E1700577B7aE261753c67e1B93Fe60Dd3e205fa
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".child.tokens.MaticToken") [staticcall]
    │   └─ ← [Return] 0x0000000000000000000000000000000000001010
    ├─ [475186] 0x6a19d7A5399D043874280Ce4B8C95612cA7A9B81::update(0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, 0xe117694b0000000000000000000000008e1700577b7ae261753c67e1b93fe60dd3e205fa00000000000000000000000000000000000000000000000000000000000010100000000000000000000000000000000000000000000000000000000000000000)
    │   ├─ [474526] 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331::update(0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, 0xe117694b0000000000000000000000008e1700577b7ae261753c67e1b93fe60dd3e205fa00000000000000000000000000000000000000000000000000000000000010100000000000000000000000000000000000000000000000000000000000000000) [delegatecall]
    │   │   ├─ [473120] 0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F::mapToken(0x8E1700577B7aE261753c67e1B93Fe60Dd3e205fa, 0x0000000000000000000000000000000000001010, false)
    │   │   │   ├─ [463408] 0x32Ac76FdbF38b50D584DD943daCDA4b07FdcBFC7::createExitQueue(0x8E1700577B7aE261753c67e1B93Fe60Dd3e205fa)
    │   │   │   │   ├─ [462751] 0xADb789e75A0BED665aCbe9fd939c4FCBa8e05410::createExitQueue(0x8E1700577B7aE261753c67e1B93Fe60Dd3e205fa) [delegatecall]
    │   │   │   │   │   ├─ [424598] → new PriorityQueue@0xF5C4e17Ae134a1F63476D7E298827CCc800d429d
    │   │   │   │   │   │   ├─ emit OwnershipTransferred(previousOwner: 0x0000000000000000000000000000000000000000, newOwner: 0x32Ac76FdbF38b50D584DD943daCDA4b07FdcBFC7)
    │   │   │   │   │   │   └─ ← [Return] 1879 bytes of code
    │   │   │   │   │   └─ ← [Stop] 
    │   │   │   │   └─ ← [Return] 
    │   │   │   ├─ emit TokenMapped(rootToken: 0x8E1700577B7aE261753c67e1B93Fe60Dd3e205fa, childToken: 0x0000000000000000000000000000000000001010)
    │   │   │   └─ ← [Stop] 
    │   │   └─ ← [Stop] 
    │   └─ ← [Return] 
    ├─ [0] console::log("Success1") [staticcall]
    │   └─ ← [Stop] 
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".root.tokens.TestToken") [staticcall]
    │   └─ ← [Return] 0x7aFE0273f78aab39BEd23062cFe1a2e21b47ca3d
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".child.tokens.TestToken") [staticcall]
    │   └─ ← [Return] 0xB3D9abe22cf0Ae3952C14d6Fa439CaD6249d6a39
    ├─ [475186] 0x6a19d7A5399D043874280Ce4B8C95612cA7A9B81::update(0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, 0xe117694b0000000000000000000000007afe0273f78aab39bed23062cfe1a2e21b47ca3d000000000000000000000000b3d9abe22cf0ae3952c14d6fa439cad6249d6a390000000000000000000000000000000000000000000000000000000000000000)
    │   ├─ [474526] 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331::update(0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, 0xe117694b0000000000000000000000007afe0273f78aab39bed23062cfe1a2e21b47ca3d000000000000000000000000b3d9abe22cf0ae3952c14d6fa439cad6249d6a390000000000000000000000000000000000000000000000000000000000000000) [delegatecall]
    │   │   ├─ [473120] 0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F::mapToken(0x7aFE0273f78aab39BEd23062cFe1a2e21b47ca3d, 0xB3D9abe22cf0Ae3952C14d6Fa439CaD6249d6a39, false)
    │   │   │   ├─ [463408] 0x32Ac76FdbF38b50D584DD943daCDA4b07FdcBFC7::createExitQueue(0x7aFE0273f78aab39BEd23062cFe1a2e21b47ca3d)
    │   │   │   │   ├─ [462751] 0xADb789e75A0BED665aCbe9fd939c4FCBa8e05410::createExitQueue(0x7aFE0273f78aab39BEd23062cFe1a2e21b47ca3d) [delegatecall]
    │   │   │   │   │   ├─ [424598] → new PriorityQueue@0xeB8849a269A562dfdCbF9A1E1097D151265660c4
    │   │   │   │   │   │   ├─ emit OwnershipTransferred(previousOwner: 0x0000000000000000000000000000000000000000, newOwner: 0x32Ac76FdbF38b50D584DD943daCDA4b07FdcBFC7)
    │   │   │   │   │   │   └─ ← [Return] 1879 bytes of code
    │   │   │   │   │   └─ ← [Stop] 
    │   │   │   │   └─ ← [Return] 
    │   │   │   ├─ emit TokenMapped(rootToken: 0x7aFE0273f78aab39BEd23062cFe1a2e21b47ca3d, childToken: 0xB3D9abe22cf0Ae3952C14d6Fa439CaD6249d6a39)
    │   │   │   └─ ← [Stop] 
    │   │   └─ ← [Stop] 
    │   └─ ← [Return] 
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".root.tokens.RootERC721") [staticcall]
    │   └─ ← [Return] 0xB3D9abe22cf0Ae3952C14d6Fa439CaD6249d6a39
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".child.tokens.RootERC721") [staticcall]
    │   └─ ← [Return] 0xb661f1577e8749456FA749d44e8A77A9d604e603
    ├─ [475186] 0x6a19d7A5399D043874280Ce4B8C95612cA7A9B81::update(0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, 0xe117694b000000000000000000000000b3d9abe22cf0ae3952c14d6fa439cad6249d6a39000000000000000000000000b661f1577e8749456fa749d44e8a77a9d604e6030000000000000000000000000000000000000000000000000000000000000001)
    │   ├─ [474526] 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331::update(0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, 0xe117694b000000000000000000000000b3d9abe22cf0ae3952c14d6fa439cad6249d6a39000000000000000000000000b661f1577e8749456fa749d44e8a77a9d604e6030000000000000000000000000000000000000000000000000000000000000001) [delegatecall]
    │   │   ├─ [473120] 0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F::mapToken(0xB3D9abe22cf0Ae3952C14d6Fa439CaD6249d6a39, 0xb661f1577e8749456FA749d44e8A77A9d604e603, true)
    │   │   │   ├─ [463408] 0x32Ac76FdbF38b50D584DD943daCDA4b07FdcBFC7::createExitQueue(0xB3D9abe22cf0Ae3952C14d6Fa439CaD6249d6a39)
    │   │   │   │   ├─ [462751] 0xADb789e75A0BED665aCbe9fd939c4FCBa8e05410::createExitQueue(0xB3D9abe22cf0Ae3952C14d6Fa439CaD6249d6a39) [delegatecall]
    │   │   │   │   │   ├─ [424598] → new PriorityQueue@0xE8a23a34567214EA0283b9e2294ef849110f47FF
    │   │   │   │   │   │   ├─ emit OwnershipTransferred(previousOwner: 0x0000000000000000000000000000000000000000, newOwner: 0x32Ac76FdbF38b50D584DD943daCDA4b07FdcBFC7)
    │   │   │   │   │   │   └─ ← [Return] 1879 bytes of code
    │   │   │   │   │   └─ ← [Stop] 
    │   │   │   │   └─ ← [Return] 
    │   │   │   ├─ emit TokenMapped(rootToken: 0xB3D9abe22cf0Ae3952C14d6Fa439CaD6249d6a39, childToken: 0xb661f1577e8749456FA749d44e8A77A9d604e603)
    │   │   │   └─ ← [Stop] 
    │   │   └─ ← [Stop] 
    │   └─ ← [Return] 
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".child.ChildChain") [staticcall]
    │   └─ ← [Return] 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331
    ├─ [6903] 0x6a19d7A5399D043874280Ce4B8C95612cA7A9B81::update(0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, 0x2026cfdc0052a858f8908b3b8c718b22328d1b5b8914e7252ae32d889f93fb147a19ef2c000000000000000000000000eafa0622b7f1a8d267cb920f9024f19d45aeb331)
    │   ├─ [6249] 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331::update(0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F, 0x2026cfdc0052a858f8908b3b8c718b22328d1b5b8914e7252ae32d889f93fb147a19ef2c000000000000000000000000eafa0622b7f1a8d267cb920f9024f19d45aeb331) [delegatecall]
    │   │   ├─ [4934] 0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F::updateContractMap(0x0052a858f8908b3b8c718b22328d1b5b8914e7252ae32d889f93fb147a19ef2c, 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331)
    │   │   │   ├─ emit ContractMapUpdated(key: 0x0052a858f8908b3b8c718b22328d1b5b8914e7252ae32d889f93fb147a19ef2c, previousContract: 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331, newContract: 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331)
    │   │   │   └─ ← [Stop] 
    │   │   └─ ← [Stop] 
    │   └─ ← [Return] 
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".root.StateSender") [staticcall]
    │   └─ ← [Return] 0xb661f1577e8749456FA749d44e8A77A9d604e603
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".root.DepositManagerProxy") [staticcall]
    │   └─ ← [Return] 0x486EDA4dF933F2251b1f060091Ae001f9c296daE
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".child.ChildChain") [staticcall]
    │   └─ ← [Return] 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331
    ├─ [6750] 0xb661f1577e8749456FA749d44e8A77A9d604e603::register(0x486EDA4dF933F2251b1f060091Ae001f9c296daE, 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331)
    │   ├─ emit RegistrationUpdated(user: 0x74Ed6F462Ef4638dc10FFb05af285e8976Fb8DC9, sender: 0x486EDA4dF933F2251b1f060091Ae001f9c296daE, receiver: 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331)
    │   └─ ← [Stop] 
    ├─ [0] VM::parseJsonAddress("<stringified JSON>", ".root.DepositManagerProxy") [staticcall]
    │   └─ ← [Return] 0x486EDA4dF933F2251b1f060091Ae001f9c296daE
    ├─ [15284] 0x486EDA4dF933F2251b1f060091Ae001f9c296daE::updateChildChainAndStateSender()
    │   ├─ [10093] 0x2a20F53eCBf6DA02BC99e08577d3fcf88D775830::updateChildChainAndStateSender() [delegatecall]
    │   │   ├─ [2896] 0x2511F0c8254bF0b3d08aAf56340D0731E7f9e22F::getChildChainAndStateSender() [staticcall]
    │   │   │   └─ ← [Return] 0xEAFA0622B7F1A8d267cb920F9024f19d45aEb331, 0xb661f1577e8749456FA749d44e8A77A9d604e603
    │   │   └─ ← [Revert] revert: Atleast one of stateSender or childChain address should change
    │   └─ ← [Revert] revert: Atleast one of stateSender or childChain address should change
    └─ ← [Revert] revert: Atleast one of stateSender or childChain address should change



== Logs ==
  Success!
  Success1
Error: script failed: revert: Atleast one of stateSender or childChain address should change
```