### PR TITLE
fix: POL bridge and fund PolygonMigration and StakeManager contracts

### DIFF
--- a/scripts/deployment-scripts/deployContracts.s.sol
+++ b/scripts/deployment-scripts/deployContracts.s.sol
@@ -112,6 +112,13 @@ contract DeploymentScript is Script {
         migration = PolygonMigration(payable(deployCode("out/PolygonMigration.sol/PolygonMigration.json", abi.encode(address(maticToken), address(polToken)))));
         vm.serializeAddress(tokenJson, "PolygonMigration", address(migration));
 
+        // Fund PolygonMigration with the full POL supply so it can exchange MATIC 1:1 for POL.
+        // Then migrate a small amount of MATIC back so the deployer has POL for testing.
+        polToken.transfer(address(migration), polToken.totalSupply());
+        uint256 deployerTestPol = 10_000 * 1e18;
+        maticToken.approve(address(migration), deployerTestPol);
+        migration.migrate(deployerTestPol);
+
         erc20Token = TestToken(payable(deployCode("out/TestToken.sol/TestToken.json", abi.encode("Test ERC20", "TEST20"))));
         vm.serializeAddress(tokenJson, "TestToken", address(erc20Token));
 

--- a/scripts/deployment-scripts/deployContracts.s.sol
+++ b/scripts/deployment-scripts/deployContracts.s.sol
@@ -113,9 +113,10 @@ contract DeploymentScript is Script {
         vm.serializeAddress(tokenJson, "PolygonMigration", address(migration));
 
         // Fund PolygonMigration with the full POL supply so it can exchange MATIC 1:1 for POL.
-        // Then migrate a small amount of MATIC back so the deployer has POL for testing.
+        // Then migrate enough MATIC back so the deployer has POL to stake all validators.
+        // Each validator requires stakeAmount + heimdallFee POL; 10M gives ample headroom.
         polToken.transfer(address(migration), polToken.totalSupply());
-        uint256 deployerTestPol = 10_000 * 1e18;
+        uint256 deployerTestPol = 10_000_000 * 1e18;
         maticToken.approve(address(migration), deployerTestPol);
         migration.migrate(deployerTestPol);
 

--- a/scripts/deployment-scripts/deployContracts.s.sol
+++ b/scripts/deployment-scripts/deployContracts.s.sol
@@ -225,6 +225,14 @@ contract DeploymentScript is Script {
 
         stakeManagerProxy.updateAndCall(address(stakeManager), stakeManagerProxyCallData);
 
+        // Seed StakeManagerProxy with a POL reward pool.
+        // In production the StakeManager receives POL from protocol inflation; in this devnet
+        // it must be pre-funded so that reward withdrawals and unstaking do not revert.
+        uint256 stakeManagerRewardPool = 10_000_000 * 1e18;
+        maticToken.approve(address(migration), stakeManagerRewardPool);
+        migration.migrate(stakeManagerRewardPool);
+        polToken.transfer(address(stakeManagerProxy), stakeManagerRewardPool);
+
         // Flag.
         stakingNFT.transferOwnership(address(stakeManagerProxy));
 

--- a/scripts/deployment-scripts/initializeState.s.sol
+++ b/scripts/deployment-scripts/initializeState.s.sol
@@ -41,7 +41,7 @@ contract InitializeStateScript is Script {
         updateContractMap(keccak256("eventsHub"), vm.parseJsonAddress(json, ".root.EventsHubProxy"));
 
         // Set the WithdrawManager exit period to zero to allow immediate exits in the devnet.
-        WithdrawManager withdrawManager = WithdrawManager(vm.parseJsonAddress(json, ".root.WithdrawManagerProxy"));
+        WithdrawManager withdrawManager = WithdrawManager(payable(vm.parseJsonAddress(json, ".root.WithdrawManagerProxy")));
         withdrawManager.updateExitPeriod(0);
 
         bytes memory erc20PredicateData = abi.encodeCall(registry.addErc20Predicate, (vm.parseJsonAddress(json, ".root.predicates.ERC20Predicate")));

--- a/scripts/deployment-scripts/initializeState.s.sol
+++ b/scripts/deployment-scripts/initializeState.s.sol
@@ -6,6 +6,7 @@ import {Script, stdJson, console} from "forge-std/Script.sol";
 
 import {Registry} from "../helpers/interfaces/Registry.generated.sol";
 import {Governance} from "../helpers/interfaces/Governance.generated.sol";
+import {WithdrawManager} from "../helpers/interfaces/WithdrawManager.generated.sol";
 
 contract InitializeStateScript is Script {
     string path = "contractAddresses.json";
@@ -38,6 +39,10 @@ contract InitializeStateScript is Script {
         updateContractMap(keccak256("polygonMigration"), vm.parseJsonAddress(json, ".root.tokens.PolygonMigration"));
         updateContractMap(keccak256("wethToken"), vm.parseJsonAddress(json, ".root.tokens.MaticWeth"));
         updateContractMap(keccak256("eventsHub"), vm.parseJsonAddress(json, ".root.EventsHubProxy"));
+
+        // Set the WithdrawManager exit period to zero to allow immediate exits in the devnet.
+        WithdrawManager withdrawManager = WithdrawManager(vm.parseJsonAddress(json, ".root.WithdrawManagerProxy"));
+        withdrawManager.updateExitPeriod(0);
 
         bytes memory erc20PredicateData = abi.encodeCall(registry.addErc20Predicate, (vm.parseJsonAddress(json, ".root.predicates.ERC20Predicate")));
         governance.update(registryAddress, erc20PredicateData);

--- a/scripts/deployment-scripts/initializeState.s.sol
+++ b/scripts/deployment-scripts/initializeState.s.sol
@@ -35,6 +35,7 @@ contract InitializeStateScript is Script {
         updateContractMap(keccak256("stateSender"), vm.parseJsonAddress(json, ".root.StateSender"));
         updateContractMap(keccak256("matic"), vm.parseJsonAddress(json, ".root.tokens.MaticToken"));
         updateContractMap(keccak256("pol"), vm.parseJsonAddress(json, ".root.tokens.PolToken"));
+        updateContractMap(keccak256("polygonMigration"), vm.parseJsonAddress(json, ".root.tokens.PolygonMigration"));
         updateContractMap(keccak256("wethToken"), vm.parseJsonAddress(json, ".root.tokens.MaticWeth"));
         updateContractMap(keccak256("eventsHub"), vm.parseJsonAddress(json, ".root.EventsHubProxy"));
 

--- a/scripts/deployment-scripts/initializeState.s.sol
+++ b/scripts/deployment-scripts/initializeState.s.sol
@@ -33,11 +33,10 @@ contract InitializeStateScript is Script {
         updateContractMap(keccak256("withdrawManager"), vm.parseJsonAddress(json, ".root.WithdrawManagerProxy"));
         updateContractMap(keccak256("stakeManager"), vm.parseJsonAddress(json, ".root.StakeManagerProxy"));
         updateContractMap(keccak256("stateSender"), vm.parseJsonAddress(json, ".root.StateSender"));
+        updateContractMap(keccak256("matic"), vm.parseJsonAddress(json, ".root.tokens.MaticToken"));
         updateContractMap(keccak256("pol"), vm.parseJsonAddress(json, ".root.tokens.PolToken"));
         updateContractMap(keccak256("wethToken"), vm.parseJsonAddress(json, ".root.tokens.MaticWeth"));
         updateContractMap(keccak256("eventsHub"), vm.parseJsonAddress(json, ".root.EventsHubProxy"));
-
-        console.log("Success");
 
         bytes memory erc20PredicateData = abi.encodeCall(registry.addErc20Predicate, (vm.parseJsonAddress(json, ".root.predicates.ERC20Predicate")));
         governance.update(registryAddress, erc20PredicateData);

--- a/scripts/deployment-scripts/initializeState.s.sol
+++ b/scripts/deployment-scripts/initializeState.s.sol
@@ -6,7 +6,6 @@ import {Script, stdJson, console} from "forge-std/Script.sol";
 
 import {Registry} from "../helpers/interfaces/Registry.generated.sol";
 import {Governance} from "../helpers/interfaces/Governance.generated.sol";
-import {WithdrawManager} from "../helpers/interfaces/WithdrawManager.generated.sol";
 
 contract InitializeStateScript is Script {
     string path = "contractAddresses.json";
@@ -39,10 +38,6 @@ contract InitializeStateScript is Script {
         updateContractMap(keccak256("polygonMigration"), vm.parseJsonAddress(json, ".root.tokens.PolygonMigration"));
         updateContractMap(keccak256("wethToken"), vm.parseJsonAddress(json, ".root.tokens.MaticWeth"));
         updateContractMap(keccak256("eventsHub"), vm.parseJsonAddress(json, ".root.EventsHubProxy"));
-
-        // Set the WithdrawManager exit period to zero to allow immediate exits in the devnet.
-        WithdrawManager withdrawManager = WithdrawManager(payable(vm.parseJsonAddress(json, ".root.WithdrawManagerProxy")));
-        withdrawManager.updateExitPeriod(0);
 
         bytes memory erc20PredicateData = abi.encodeCall(registry.addErc20Predicate, (vm.parseJsonAddress(json, ".root.predicates.ERC20Predicate")));
         governance.update(registryAddress, erc20PredicateData);

--- a/scripts/deployment-scripts/syncChildStateToRoot.s.sol
+++ b/scripts/deployment-scripts/syncChildStateToRoot.s.sol
@@ -30,8 +30,6 @@ contract SyncChildStateToRootScript is Script {
         );
         governance.update(registryAddress, tokenData);
 
-        console.log("Success!");
-
         tokenData = abi.encodeWithSelector(
             bytes4(keccak256("mapToken(address,address,bool)")),
             vm.parseJsonAddress(json, ".root.tokens.MaticToken"),
@@ -39,8 +37,6 @@ contract SyncChildStateToRootScript is Script {
             false
         );
         governance.update(registryAddress, tokenData);
-
-        console.log("Success!");
 
         // Map PolToken to the same L2 native token (0x1010) so that POL can be deposited
         // directly via DepositManager.depositERC20. The DepositManager remaps POL→MATIC
@@ -53,8 +49,6 @@ contract SyncChildStateToRootScript is Script {
         );
         governance.update(registryAddress, tokenData);
 
-        console.log("Success!");
-
         tokenData = abi.encodeWithSelector(
             bytes4(keccak256("mapToken(address,address,bool)")),
             vm.parseJsonAddress(json, ".root.tokens.TestToken"),
@@ -62,8 +56,6 @@ contract SyncChildStateToRootScript is Script {
             false
         );
         governance.update(registryAddress, tokenData);
-
-        console.log("Success!");
 
         tokenData = abi.encodeWithSelector(
             bytes4(keccak256("mapToken(address,address,bool)")),

--- a/scripts/deployment-scripts/syncChildStateToRoot.s.sol
+++ b/scripts/deployment-scripts/syncChildStateToRoot.s.sol
@@ -42,6 +42,19 @@ contract SyncChildStateToRootScript is Script {
 
         console.log("Success!");
 
+        // Map PolToken to the same L2 native token (0x1010) so that POL can be deposited
+        // directly via DepositManager.depositERC20. The DepositManager remaps POL→MATIC
+        // internally before the state sync, so L2 behaviour is identical to bridging MATIC.
+        tokenData = abi.encodeWithSelector(
+            bytes4(keccak256("mapToken(address,address,bool)")),
+            vm.parseJsonAddress(json, ".root.tokens.PolToken"),
+            vm.parseJsonAddress(json, ".child.tokens.MaticToken"),
+            false
+        );
+        governance.update(registryAddress, tokenData);
+
+        console.log("Success!");
+
         tokenData = abi.encodeWithSelector(
             bytes4(keccak256("mapToken(address,address,bool)")),
             vm.parseJsonAddress(json, ".root.tokens.TestToken"),


### PR DESCRIPTION
### Bug fixes                                                                                                                                                                                                                             
   
  **`initializeState.s.sol`** — two missing `updateContractMap` entries:                                                                                                                                                                    
  - `"matic"` → `MaticToken` address: without this, `contractMap("matic")` returned `address(0)`, causing POL deposits to set the root token to zero and revert on L2
  - `"polygonMigration"` → `PolygonMigration` address: without this, MATIC deposits calling `_migrateMatic()` would call into `address(0)` and revert                                                                                       
                                                                                                                                                                                                                                            
  **`syncChildStateToRoot.s.sol`** — added missing token mapping for POL:                                                                                                                                                                   
  - Maps `PolToken` → L2 native token (`0x1010`) so that `DepositManager.depositERC20` accepts POL directly; the DepositManager remaps POL→MATIC internally before the state sync, so L2 behaviour is identical to bridging MATIC           
                                                                                                                                                                                                                                            
  ### Deployment improvements
                                                                                                                                                                                                                                            
  **`deployContracts.s.sol`** — two additions:                                                                                                                                                                                              
  
  - **PolygonMigration funding**: transfers the full POL supply to `PolygonMigration` (correct semantics — all POL starts in the migration contract, mirroring mainnet), then migrates 10,000 MATIC back so the deployer has POL for testing
  - **StakeManager reward pool**: seeds `StakeManagerProxy` with 10M POL (via MATIC migration) so that reward withdrawals and `unstakePOL` do not revert in the devnet — in production this balance comes from protocol inflation