### PR TITLE
PIP-86 Recalibrate CHECKPOINT_REWARD for reduced Polygon block times

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,27 +29,27 @@
     "mnemonics": "clock radar mass judge dismiss just intact mind resemble fringe diary casino"
   },
   "devDependencies": {
-    "@openzeppelin/test-helpers": "^0.5.16",
     "@nomicfoundation/hardhat-toolbox": "^2.0.0",
     "@nomiclabs/hardhat-web3": "2.0.0",
-    "esm": "3.2.25",
+    "@openzeppelin/test-helpers": "^0.5.16",
     "bip39": "^2.5.0",
     "dotenv": "^16.3.1",
-    "ethereumjs-wallet": "1.0.2",
-    "eth-sig-util": "^2.1.1",
-    "prettier": "^3.0.3",
-    "solidity-coverage": "0.8.4",
     "eslint": "^8.55.0",
+    "esm": "3.2.25",
+    "eth-sig-util": "^2.1.1",
     "ethereumjs-block": "^2.2.2",
     "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^6.0.0",
+    "ethereumjs-wallet": "1.0.2",
     "ganache": "7.9.2",
     "import-toml": "^1.0.0",
     "merkle-patricia-tree": "^2.3.2",
     "mocha": "10.2.0",
-    "nunjucks": "^3.2.0"
+    "nunjucks": "^3.2.0",
+    "prettier": "^3.0.3",
+    "solidity-coverage": "0.8.4",
+    "pre-commit": "^2.0.0"
   },
-  "dependencies": {},
   "eslintConfig": {
     "env": {
       "browser": false,

--- a/scripts/deployers/pol-upgrade/UpdateCheckPointReward.s.sol
+++ b/scripts/deployers/pol-upgrade/UpdateCheckPointReward.s.sol
@@ -32,7 +32,7 @@ contract UpgradeStake_DepositManager_Mainnet is Script {
         governance = input.readAddress(string.concat(chainIdSlug, ".governance"));
         timelock = Timelock(payable(input.readAddress(string.concat(chainIdSlug, ".timelock"))));
 
-        uint256 NEW_REWARD = 29414916286149162861491;
+        uint256 NEW_REWARD = 25212785388127853881278;
         address polygonBridgeMultisig = input.readAddress(string.concat(chainIdSlug, ".gSafe"));
 
         // create payload

--- a/scripts/deployers/pol-upgrade/UpdateCheckPointReward.s.sol
+++ b/scripts/deployers/pol-upgrade/UpdateCheckPointReward.s.sol
@@ -32,7 +32,8 @@ contract UpgradeStake_DepositManager_Mainnet is Script {
         governance = input.readAddress(string.concat(chainIdSlug, ".governance"));
         timelock = Timelock(payable(input.readAddress(string.concat(chainIdSlug, ".timelock"))));
 
-        uint256 NEW_REWARD = 37108000000000000000000;
+        uint256 NEW_REWARD = 29414916286149162861491;
+        address polygonBridgeMultisig = input.readAddress(string.concat(chainIdSlug, ".gSafe"));
 
         // create payload
         bytes memory payload = abi.encodeCall(Governance.update, (stakeManagerProxy, abi.encodeCall(StakeManager.updateCheckpointReward, (NEW_REWARD))));
@@ -40,10 +41,12 @@ contract UpgradeStake_DepositManager_Mainnet is Script {
         bytes memory schedulePayload = abi.encodeCall(Timelock.schedule, (governance, 0, payload, "", "", 0));
         bytes memory executePayload = abi.encodeCall(Timelock.execute, (governance, 0, payload, "", ""));
 
+        console.log("use polygonBridgeMultisig: ", polygonBridgeMultisig);
+        console.log("send to: ", address(timelock));
         console.log("Scheduling payload: ", vm.toString(schedulePayload));
         console.log("Executing payload: ", vm.toString(executePayload));
 
-        vm.startPrank(0xFa7D2a996aC6350f4b56C043112Da0366a59b74c);
+        vm.startPrank(polygonBridgeMultisig);
         
         address(timelock).call(schedulePayload);
         address(timelock).call(executePayload);


### PR DESCRIPTION

# PIP-86

  ## Abstract

  Polygon PoS is reducing its average block time in two steps, from approximately 2s to 1.75s, and subsequently to 1.5s. Because checkpoints are submitted every `checkPointBlockInterval = 5120` blocks, a shorter
  block time directly increases the number of checkpoints submitted per year. The per-checkpoint emission parameter `CHECKPOINT_REWARD`, set on the L1 `StakeManager` (`0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908`)
  and updated through `updateCheckpointReward(uint256)`, must therefore be reduced proportionally.  
  This PIP proposes two new values, each to be applied at the moment its corresponding
  block-time change goes live:  
  **29,414.92 POL** when block time becomes 1.75s, and **25,212.79 POL** when block time becomes 1.5s.

## Relevant links
PIP: https://github.com/0xPolygon/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-86.md

Script: https://github.com/0xPolygon/pos-contracts/blob/main/scripts/deployers/pol-upgrade/UpdateCheckPointReward.s.sol