### PR TITLE
feat(staking): permission validator entry via single-use ValidatorPass

### DIFF
--- a/contracts/staking/stakeManager/IValidatorPass.sol
+++ b/contracts/staking/stakeManager/IValidatorPass.sol
@@ -6,9 +6,15 @@ pragma solidity 0.5.17;
 interface IValidatorPass {
     /// @notice Consume a validator's single-use pass on entry. Governance authorizes by issuing the
     ///         pass; this consumes it. State-changing, so implementations MUST restrict it to the
-    ///         StakeManager.
+    ///         StakeManager. This call is the frozen boundary of the pass system (widening it later
+    ///         requires a StakeManager upgrade), so it forwards the full entry context; modules are
+    ///         free to ignore what their policy does not need.
     /// @param validator Prospective validator (the `user` of `stakeFor`).
     /// @param signerPubkey Consensus key supplied to `stakeFor`.
+    /// @param amount Stake amount the entrant is joining with (excludes the heimdall fee).
+    /// @param funder `msg.sender` of the stake call — the account paying (third-party entry allowed).
     /// @return consumed True if a valid pass was consumed (entry permitted); false otherwise.
-    function consumePass(address validator, bytes calldata signerPubkey) external returns (bool consumed);
+    function consumePass(address validator, bytes calldata signerPubkey, uint256 amount, address funder)
+        external
+        returns (bool consumed);
 }

--- a/contracts/staking/stakeManager/IValidatorPass.sol
+++ b/contracts/staking/stakeManager/IValidatorPass.sol
@@ -1,0 +1,14 @@
+pragma solidity 0.5.17;
+
+/// @title IValidatorPass
+/// @notice Hook the StakeManager calls to permission validator entry, resolved from the Registry
+///         under `keccak256("validatorPass")` (unset => permissionless).
+interface IValidatorPass {
+    /// @notice Consume a validator's single-use pass on entry. Governance authorizes by issuing the
+    ///         pass; this consumes it. State-changing, so implementations MUST restrict it to the
+    ///         StakeManager.
+    /// @param validator Prospective validator (the `user` of `stakeFor`).
+    /// @param signerPubkey Consensus key supplied to `stakeFor`.
+    /// @return consumed True if a valid pass was consumed (entry permitted); false otherwise.
+    function consumePass(address validator, bytes calldata signerPubkey) external returns (bool consumed);
+}

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -19,6 +19,8 @@ import {IGovernance} from "../../common/governance/IGovernance.sol";
 import {Initializable} from "../../common/mixin/Initializable.sol";
 import {StakeManagerExtension} from "./StakeManagerExtension.sol";
 import {IPolygonMigration} from "../../common/misc/IPolygonMigration.sol";
+import {Registry} from "../../common/Registry.sol";
+import {IValidatorPass} from "./IValidatorPass.sol";
 
 contract StakeManager is
     StakeManagerStorage,
@@ -29,6 +31,9 @@ contract StakeManager is
 {
     using SafeMath for uint256;
     using Merkle for bytes32;
+
+    // Registry key of the optional validator-pass module that permissions new validator entry.
+    bytes32 constant VALIDATOR_PASS_KEY = keccak256("validatorPass");
 
     struct UnsignedValidatorsContext {
         uint256 unsignedValidatorIndex;
@@ -401,6 +406,14 @@ contract StakeManager is
     ) internal {
         require(currentValidatorSetSize() < validatorThreshold, "no more slots");
         require(amount >= minDeposit, "not enough deposit");
+
+        // Permissioned entry: a registered validator-pass module must consume a single-use pass for
+        // the entrant (issued by governance) before funds move; unregistered => permissionless.
+        address validatorPass = Registry(registry).contractMap(VALIDATOR_PASS_KEY);
+        if (validatorPass != address(0)) {
+            require(IValidatorPass(validatorPass).consumePass(user, signerPubkey), "no valid pass");
+        }
+
         _transferAndTopUp(user, msg.sender, heimdallFee, amount, pol);
         _stakeFor(user, amount, acceptDelegation, signerPubkey);
     }

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -411,7 +411,10 @@ contract StakeManager is
         // the entrant (issued by governance) before funds move; unregistered => permissionless.
         address validatorPass = Registry(registry).contractMap(VALIDATOR_PASS_KEY);
         if (validatorPass != address(0)) {
-            require(IValidatorPass(validatorPass).consumePass(user, signerPubkey), "no valid pass");
+            require(
+                IValidatorPass(validatorPass).consumePass(user, signerPubkey, amount, msg.sender),
+                "no valid pass"
+            );
         }
 
         _transferAndTopUp(user, msg.sender, heimdallFee, amount, pol);


### PR DESCRIPTION
## Description

Adds an optional permissioning hook to validator-set entry. `StakeManager._stakeFor` resolves a module from the Registry under `keccak256("validatorPass")` (constant `VALIDATOR_PASS_KEY`) and, when set, requires it to `consumePass(user, signerPubkey)` before any funds move; unset (`address(0)`) keeps entry **permissionless** (fully backward compatible). The consume is atomic — a downstream revert rolls it back. Existing validators are unaffected: their operations are NFT-gated and never reach the gate.

This PR is intentionally minimal — only the `StakeManager` gate and the `IValidatorPass` interface. The module implementation (`ValidatorPass`) and its tests now live in the v2 repo: 0xPolygon/pos-contracts-v2#3.

### How Has This Been Tested?

- `forge build` — compiles cleanly with the gate + interface; `ValidatorShareTest` regression unaffected.
- Full behavior (issue/redeem, single-use, key binding, expiry, revoke, permissionless fallback, mainnet-fork upgrade playbook) is exercised against this StakeManager in 0xPolygon/pos-contracts-v2#3, which builds this branch and runs the suite.
