### PR TITLE
Pin non-upgradeable contracts to their on-chain bytecode

### DIFF
--- a/contracts/child/ChildChain.sol
+++ b/contracts/child/ChildChain.sol
@@ -5,9 +5,18 @@ import {Ownable} from "../common/oz/ownership/Ownable.sol";
 import {StateSyncerVerifier} from "./bor/StateSyncerVerifier.sol";
 import {StateReceiver} from "./bor/StateReceiver.sol";
 
-import {ChildToken} from "./ChildToken.sol";
-import {ChildERC20} from "./ChildERC20.sol";
-import {ChildERC721} from "./ChildERC721.sol";
+// This is the immutable, non-upgradeable plasma ChildChain deployed at
+// 0xD9c7C4ED4B66858301D0cb28Cc88bf655Fe34861 (solc 0.5.11, bor-chain-id 137).
+// Its bytecode embeds the CREATION code of the child tokens it auto-deploys via
+// `new ChildERC20(...)` / `new ChildERC721(...)`, so it must reference the
+// PRE-REFACTOR token code (parentOwner ownership, "Matic Network"/v1 EIP712, no
+// StateSyncer/onStateReceive) to reproduce byte-for-byte. That old token code
+// lives in contracts/child/legacy/*. The modern ChildERC20/ChildERC721 in
+// contracts/child/ are the base for the live proxified child-token path and
+// must not be embedded here. Logic below is otherwise unchanged.
+import {ChildTokenLegacy as ChildToken} from "./legacy/ChildTokenLegacy.sol";
+import {ChildERC20Legacy as ChildERC20} from "./legacy/ChildERC20Legacy.sol";
+import {ChildERC721Legacy as ChildERC721} from "./legacy/ChildERC721Legacy.sol";
 
 contract ChildChain is Ownable, StateSyncerVerifier, StateReceiver {
     // mapping for (root token => child token)

--- a/contracts/child/legacy/BaseERC20Legacy.sol
+++ b/contracts/child/legacy/BaseERC20Legacy.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.5.2;
+
+import {ChildTokenLegacy} from "./ChildTokenLegacy.sol";
+
+// FROZEN. Reproduces the old on-chain child-token code embedded in the immutable
+// plasma ChildChain 0xD9c7C4ED4B66858301D0cb28Cc88bf655Fe34861 (solc 0.5.11,
+// bor-chain-id 137). Do not edit.
+//
+// Old-code marker preserved vs the modern BaseERC20.sol: transferWithSig builds
+// the digest with getTokenTransferOrderHash (which uses the CACHED
+// hashEIP712Message domain hash), NOT the modern
+// hashEIP712MessageWithAddress(..., address(this)).
+contract BaseERC20Legacy is ChildTokenLegacy {
+    event Deposit(
+        address indexed token,
+        address indexed from,
+        uint256 amount,
+        uint256 input1,
+        uint256 output1
+    );
+
+    event Withdraw(
+        address indexed token,
+        address indexed from,
+        uint256 amount,
+        uint256 input1,
+        uint256 output1
+    );
+
+    event LogTransfer(
+        address indexed token,
+        address indexed from,
+        address indexed to,
+        uint256 amount,
+        uint256 input1,
+        uint256 input2,
+        uint256 output1,
+        uint256 output2
+    );
+
+    constructor() public {}
+
+    function transferWithSig(
+        bytes calldata sig,
+        uint256 amount,
+        bytes32 data,
+        uint256 expiration,
+        address to
+    ) external returns (address from) {
+        require(amount > 0);
+        require(expiration == 0 || block.number <= expiration, "Signature is expired");
+
+        bytes32 dataHash = getTokenTransferOrderHash(msg.sender, amount, data, expiration);
+        require(disabledHashes[dataHash] == false, "Sig deactivated");
+        disabledHashes[dataHash] = true;
+
+        from = ecrecovery(dataHash, sig);
+        _transferFrom(from, address(uint160(to)), amount);
+    }
+
+    function balanceOf(address account) external view returns (uint256);
+    function _transfer(address sender, address recipient, uint256 amount) internal;
+
+    /// @param from Address from where tokens are withdrawn.
+    /// @param to Address to where tokens are sent.
+    /// @param value Number of tokens to transfer.
+    /// @return Returns success of function call.
+    function _transferFrom(address from, address to, uint256 value) internal returns (bool) {
+        uint256 input1 = this.balanceOf(from);
+        uint256 input2 = this.balanceOf(to);
+        _transfer(from, to, value);
+        emit LogTransfer(token, from, to, value, input1, input2, this.balanceOf(from), this.balanceOf(to));
+        return true;
+    }
+}

--- a/contracts/child/legacy/ChildERC20Legacy.sol
+++ b/contracts/child/legacy/ChildERC20Legacy.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.5.2;
+
+import {ERC20Detailed} from "../ERC20Detailed.sol";
+import {ERC20} from "../../common/oz/token/ERC20/ERC20.sol";
+
+import {BaseERC20Legacy} from "./BaseERC20Legacy.sol";
+import {IParentToken} from "../misc/IParentToken.sol";
+
+// FROZEN. Reproduces the old on-chain child-token code embedded in the immutable
+// plasma ChildChain 0xD9c7C4ED4B66858301D0cb28Cc88bf655Fe34861 (solc 0.5.11,
+// bor-chain-id 137). This is the runtime auto-deployed for the old MaticWETH and
+// TestToken child instances (0x8cc8… / 0x5E1D…). Do not edit.
+//
+// Old-code markers preserved vs the modern ChildERC20.sol:
+//   - does NOT inherit StateSyncerVerifier / StateReceiver (no onStateReceive)
+//   - constructor sets parentOwner = _owner (modern ignores it)
+//   - deposit is onlyOwner and withdraw is inlined (no _withdraw helper)
+//   - setParent is isParentOwner (modern setParent lives in ChildToken)
+contract ChildERC20Legacy is BaseERC20Legacy, ERC20, ERC20Detailed {
+    constructor(
+        address _owner,
+        address _token,
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals
+    ) public ERC20Detailed(_name, _symbol, _decimals) {
+        require(_token != address(0x0) && _owner != address(0x0));
+        parentOwner = _owner;
+        token = _token;
+    }
+
+    function setParent(address _parent) public isParentOwner {
+        require(_parent != address(0x0));
+        parent = _parent;
+    }
+
+    /**
+     * Deposit tokens
+     *
+     * @param user address for address
+     * @param amount token balance
+     */
+    function deposit(address user, uint256 amount) public onlyOwner {
+        // check for amount and user
+        require(amount > 0 && user != address(0x0));
+
+        // input balance
+        uint256 input1 = balanceOf(user);
+
+        // increase balance
+        _mint(user, amount);
+
+        // deposit events
+        emit Deposit(token, user, amount, input1, balanceOf(user));
+    }
+
+    /**
+     * Withdraw tokens
+     *
+     * @param amount tokens
+     */
+    function withdraw(uint256 amount) public payable {
+        address user = msg.sender;
+        // input balance
+        uint256 input = balanceOf(user);
+
+        // check for amount
+        require(amount > 0 && input >= amount);
+
+        // decrease balance
+        _burn(user, amount);
+
+        // withdraw event
+        emit Withdraw(token, user, amount, input, balanceOf(user));
+    }
+
+    /// @dev Function that is called when a user or another contract wants to transfer funds.
+    /// @param to Address of token receiver.
+    /// @param value Number of tokens to transfer.
+    /// @return Returns success of function call.
+    function transfer(address to, uint256 value) public returns (bool) {
+        if (parent != address(0x0) && !IParentToken(parent).beforeTransfer(msg.sender, to, value)) {
+            return false;
+        }
+        return _transferFrom(msg.sender, to, value);
+    }
+
+    function allowance(address, address) public view returns (uint256) {
+        revert("Disabled feature");
+    }
+
+    function approve(address, uint256) public returns (bool) {
+        revert("Disabled feature");
+    }
+
+    function transferFrom(address, address, uint256) public returns (bool) {
+        revert("Disabled feature");
+    }
+}

--- a/contracts/child/legacy/ChildERC721Legacy.sol
+++ b/contracts/child/legacy/ChildERC721Legacy.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.5.2;
+
+import {ERC721Full} from "../../common/oz/token/ERC721/ERC721Full.sol";
+
+import {ChildTokenLegacy} from "./ChildTokenLegacy.sol";
+import {IParentToken} from "../misc/IParentToken.sol";
+
+// FROZEN. Reproduces the old on-chain child-token code embedded in the immutable
+// plasma ChildChain 0xD9c7C4ED4B66858301D0cb28Cc88bf655Fe34861 (solc 0.5.11,
+// bor-chain-id 137). This is the runtime auto-deployed for the old RootERC721
+// child instance (0xa353…). Do not edit.
+//
+// Old-code markers preserved vs the modern ChildERC721.sol:
+//   - does NOT inherit StateSyncerVerifier / StateReceiver (no onStateReceive)
+//   - constructor sets parentOwner = _owner (modern ignores it)
+//   - transferWithSig builds the digest with getTokenTransferOrderHash (cached
+//     "Matic Network"/v1 domain), NOT hashEIP712MessageWithAddress
+//   - deposit is onlyOwner, setParent is isParentOwner
+contract ChildERC721Legacy is ChildTokenLegacy, ERC721Full {
+    event Deposit(address indexed token, address indexed from, uint256 tokenId);
+
+    event Withdraw(address indexed token, address indexed from, uint256 tokenId);
+
+    event LogTransfer(address indexed token, address indexed from, address indexed to, uint256 tokenId);
+
+    constructor(
+        address _owner,
+        address _token,
+        string memory name,
+        string memory symbol
+    ) public ERC721Full(name, symbol) {
+        require(_token != address(0x0) && _owner != address(0x0));
+        parentOwner = _owner;
+        token = _token;
+    }
+
+    function transferWithSig(
+        bytes calldata sig,
+        uint256 tokenId,
+        bytes32 data,
+        uint256 expiration,
+        address to
+    ) external returns (address) {
+        require(expiration == 0 || block.number <= expiration, "Signature is expired");
+
+        bytes32 dataHash = getTokenTransferOrderHash(msg.sender, tokenId, data, expiration);
+        require(disabledHashes[dataHash] == false, "Sig deactivated");
+        disabledHashes[dataHash] = true;
+
+        // recover address and send tokens
+        address from = ecrecovery(dataHash, sig);
+        _transferFrom(from, to, tokenId);
+        require(_checkOnERC721Received(from, to, tokenId, ""), "_checkOnERC721Received failed");
+        return from;
+    }
+
+    function setParent(address _parent) public isParentOwner {
+        require(_parent != address(0x0));
+        parent = _parent;
+    }
+
+    function approve(address to, uint256 tokenId) public {
+        revert("Disabled feature");
+    }
+
+    function getApproved(uint256 tokenId) public view returns (address operator) {
+        revert("Disabled feature");
+    }
+
+    function setApprovalForAll(address operator, bool _approved) public {
+        revert("Disabled feature");
+    }
+
+    function isApprovedForAll(address owner, address operator) public view returns (bool) {
+        revert("Disabled feature");
+    }
+
+    /**
+     * @notice Deposit tokens
+     * @param user address for deposit
+     * @param tokenId tokenId to mint to user's account
+     */
+    function deposit(address user, uint256 tokenId) public onlyOwner {
+        require(user != address(0x0));
+        _mint(user, tokenId);
+        emit Deposit(token, user, tokenId);
+    }
+
+    /**
+     * @notice Withdraw tokens
+     * @param tokenId tokenId of the token to be withdrawn
+     */
+    function withdraw(uint256 tokenId) public payable {
+        require(ownerOf(tokenId) == msg.sender);
+        _burn(msg.sender, tokenId);
+        emit Withdraw(token, msg.sender, tokenId);
+    }
+
+    /**
+     * @dev Overriding the inherited method so that it emits LogTransfer
+     */
+    function transferFrom(address from, address to, uint256 tokenId) public {
+        if (parent != address(0x0) && !IParentToken(parent).beforeTransfer(msg.sender, to, tokenId)) {
+            return;
+        }
+        _transferFrom(from, to, tokenId);
+    }
+
+    function _transferFrom(address from, address to, uint256 tokenId) internal {
+        super._transferFrom(from, to, tokenId);
+        emit LogTransfer(token, from, to, tokenId);
+    }
+}

--- a/contracts/child/legacy/ChildTokenLegacy.sol
+++ b/contracts/child/legacy/ChildTokenLegacy.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.5.2;
+
+import {SafeMath} from "../../common/oz/math/SafeMath.sol";
+import {Ownable} from "../../common/oz/ownership/Ownable.sol";
+
+import {LibTokenTransferOrderLegacy} from "./LibTokenTransferOrderLegacy.sol";
+
+// FROZEN. Reproduces the old on-chain child-token code embedded in the immutable
+// plasma ChildChain 0xD9c7C4ED4B66858301D0cb28Cc88bf655Fe34861 (solc 0.5.11,
+// bor-chain-id 137). Do not edit.
+//
+// Old-code markers preserved vs the modern ChildToken.sol:
+//   - `parentOwner` + `isParentOwner` modifier (modern uses `childChain` +
+//     `onlyChildChain`)
+//   - abstract `setParent(address)` (modern has a concrete setParent w/ event)
+//   - NO StateSyncer/StateReceiver wiring, NO changeChildChain
+contract ChildTokenLegacy is Ownable, LibTokenTransferOrderLegacy {
+    using SafeMath for uint256;
+
+    // ERC721/ERC20 contract token address on root chain
+    address public token;
+    address public parent;
+    address public parentOwner;
+
+    mapping(bytes32 => bool) public disabledHashes;
+
+    modifier isParentOwner() {
+        require(msg.sender == parentOwner);
+        _;
+    }
+
+    function deposit(address user, uint256 amountOrTokenId) public;
+    function withdraw(uint256 amountOrTokenId) public payable;
+    function setParent(address _parent) public;
+
+    event LogFeeTransfer(
+        address indexed token,
+        address indexed from,
+        address indexed to,
+        uint256 amount,
+        uint256 input1,
+        uint256 input2,
+        uint256 output1,
+        uint256 output2
+    );
+
+    function ecrecovery(bytes32 hash, bytes memory sig) public pure returns (address result) {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        if (sig.length != 65) {
+            return address(0x0);
+        }
+        assembly {
+            r := mload(add(sig, 32))
+            s := mload(add(sig, 64))
+            v := and(mload(add(sig, 65)), 255)
+        }
+        // https://github.com/ethereum/go-ethereum/issues/2053
+        if (v < 27) {
+            v += 27;
+        }
+        if (v != 27 && v != 28) {
+            return address(0x0);
+        }
+        // get address out of hash and signature
+        result = ecrecover(hash, v, r, s);
+        // ecrecover returns zero on error
+        require(result != address(0x0), "Error in ecrecover");
+    }
+}

--- a/contracts/child/legacy/EIP712Legacy.sol
+++ b/contracts/child/legacy/EIP712Legacy.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.5.2;
+
+import {ChainIdMixin} from "../../common/mixin/ChainIdMixin.sol";
+
+// FROZEN. Reproduces the old on-chain child-token EIP712 base embedded in the
+// immutable plasma ChildChain 0xD9c7C4ED4B66858301D0cb28Cc88bf655Fe34861
+// (solc 0.5.11, bor-chain-id 137). Do not edit.
+//
+// Old-code markers preserved vs the modern misc/EIP712.sol:
+//   - domain name "Matic Network" / version "1" (modern is "Polygon Ecosystem
+//     Token" / "2")
+//   - hashEIP712Message with the domain hash cached in EIP712_DOMAIN_HASH
+//   - NO hashEIP712MessageWithAddress helper (added in the modern refactor)
+contract LibEIP712DomainLegacy is ChainIdMixin {
+    string internal constant EIP712_DOMAIN_SCHEMA =
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)";
+    bytes32 public constant EIP712_DOMAIN_SCHEMA_HASH = keccak256(abi.encodePacked(EIP712_DOMAIN_SCHEMA));
+
+    string internal constant EIP712_DOMAIN_NAME = "Matic Network";
+    string internal constant EIP712_DOMAIN_VERSION = "1";
+    uint256 internal constant EIP712_DOMAIN_CHAINID = CHAINID;
+
+    bytes32 public EIP712_DOMAIN_HASH;
+
+    constructor() public {
+        EIP712_DOMAIN_HASH = keccak256(
+            abi.encode(
+                EIP712_DOMAIN_SCHEMA_HASH,
+                keccak256(bytes(EIP712_DOMAIN_NAME)),
+                keccak256(bytes(EIP712_DOMAIN_VERSION)),
+                EIP712_DOMAIN_CHAINID,
+                address(this)
+            )
+        );
+    }
+
+    function hashEIP712Message(bytes32 hashStruct) internal view returns (bytes32 result) {
+        bytes32 domainHash = EIP712_DOMAIN_HASH;
+
+        // Assembly for more efficient computing:
+        // keccak256(abi.encode(
+        //     EIP191_HEADER,
+        //     domainHash,
+        //     hashStruct
+        // ));
+
+        assembly {
+            // Load free memory pointer
+            let memPtr := mload(64)
+
+            mstore(memPtr, 0x1901000000000000000000000000000000000000000000000000000000000000) // EIP191 header
+            mstore(add(memPtr, 2), domainHash) // EIP712 domain hash
+            mstore(add(memPtr, 34), hashStruct) // Hash of struct
+
+            // Compute hash
+            result := keccak256(memPtr, 66)
+        }
+        return result;
+    }
+}

--- a/contracts/child/legacy/LibTokenTransferOrderLegacy.sol
+++ b/contracts/child/legacy/LibTokenTransferOrderLegacy.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.5.2;
+
+import {LibEIP712DomainLegacy} from "./EIP712Legacy.sol";
+
+// FROZEN. Reproduces the old on-chain child-token code embedded in the immutable
+// plasma ChildChain 0xD9c7C4ED4B66858301D0cb28Cc88bf655Fe34861 (solc 0.5.11,
+// bor-chain-id 137). Do not edit.
+//
+// The body is byte-identical to the modern misc/LibTokenTransferOrder.sol; the
+// only reason a legacy copy exists is to re-parent onto LibEIP712DomainLegacy so
+// the legacy token stack resolves the "Matic Network"/v1 domain instead of the
+// modern one.
+contract LibTokenTransferOrderLegacy is LibEIP712DomainLegacy {
+    string internal constant EIP712_TOKEN_TRANSFER_ORDER_SCHEMA =
+        "TokenTransferOrder(address spender,uint256 tokenIdOrAmount,bytes32 data,uint256 expiration)";
+    bytes32 public constant EIP712_TOKEN_TRANSFER_ORDER_SCHEMA_HASH =
+        keccak256(abi.encodePacked(EIP712_TOKEN_TRANSFER_ORDER_SCHEMA));
+
+    struct TokenTransferOrder {
+        address spender;
+        uint256 tokenIdOrAmount;
+        bytes32 data;
+        uint256 expiration;
+    }
+
+    function getTokenTransferOrderHash(
+        address spender,
+        uint256 tokenIdOrAmount,
+        bytes32 data,
+        uint256 expiration
+    ) public view returns (bytes32 orderHash) {
+        orderHash = hashEIP712Message(hashTokenTransferOrder(spender, tokenIdOrAmount, data, expiration));
+    }
+
+    function hashTokenTransferOrder(
+        address spender,
+        uint256 tokenIdOrAmount,
+        bytes32 data,
+        uint256 expiration
+    ) internal pure returns (bytes32 result) {
+        bytes32 schemaHash = EIP712_TOKEN_TRANSFER_ORDER_SCHEMA_HASH;
+
+        // Assembly for more efficiently computing:
+        // return keccak256(abi.encode(
+        //   schemaHash,
+        //   spender,
+        //   tokenIdOrAmount,
+        //   data,
+        //   expiration
+        // ));
+
+        assembly {
+            // Load free memory pointer
+            let memPtr := mload(64)
+
+            mstore(memPtr, schemaHash) // hash of schema
+            mstore(add(memPtr, 32), and(spender, 0xffffffffffffffffffffffffffffffffffffffff)) // spender
+            mstore(add(memPtr, 64), tokenIdOrAmount) // tokenIdOrAmount
+            mstore(add(memPtr, 96), data) // hash of data
+            mstore(add(memPtr, 128), expiration) // expiration
+
+            // Compute hash
+            result := keccak256(memPtr, 160)
+        }
+        return result;
+    }
+}

--- a/contracts/common/Registry.sol
+++ b/contracts/common/Registry.sol
@@ -1,9 +1,13 @@
 pragma solidity ^0.5.2;
 
-import {Governable} from "./governance/Governable.sol";
+import {GovernableLegacy} from "./governance/GovernableLegacy.sol";
 import {IWithdrawManager} from "../root/withdrawManager/IWithdrawManager.sol";
 
-contract Registry is Governable {
+// Registry has a single, immutable deployment that predates the Governable
+// refactor (commit 49b39d8a). It therefore inherits GovernableLegacy (the old
+// inlined onlyGovernance) so a normal `forge build` reproduces its on-chain
+// bytecode. Behaviour is identical to the modern Governable.
+contract Registry is GovernableLegacy {
     // @todo hardcode constants
     bytes32 private constant WETH_TOKEN = keccak256("wethToken");
     bytes32 private constant DEPOSIT_MANAGER = keccak256("depositManager");
@@ -43,7 +47,7 @@ contract Registry is Governable {
     event PredicateRemoved(address indexed predicate, address indexed from);
     event ContractMapUpdated(bytes32 indexed key, address indexed previousContract, address indexed newContract);
 
-    constructor(address _governance) public Governable(_governance) {}
+    constructor(address _governance) public GovernableLegacy(_governance) {}
 
     function updateContractMap(bytes32 _key, address _address) external onlyGovernance {
         emit ContractMapUpdated(_key, contractMap[_key], _address);

--- a/contracts/common/governance/GovernableLegacy.sol
+++ b/contracts/common/governance/GovernableLegacy.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.5.2;
+
+import {IGovernance} from "./IGovernance.sol";
+
+// Frozen, pre-refactor Governable (onlyGovernance inlined at each use site).
+//
+// The modern Governable (governance/Governable.sol) extracts the check into a
+// private _assertGovernance() helper (commit 49b39d8a). That refactor is used by
+// the currently-deployed implementations (StakeManager/WithdrawManager/
+// DepositManager/RootChain), so it must stay. Immutable contracts deployed
+// BEFORE the refactor (Registry) inherit this legacy copy instead, so a normal
+// `forge build` reproduces their on-chain bytecode. Behaviour is identical to the
+// modern version; only the bytecode shape differs. Do not edit.
+contract GovernableLegacy {
+    IGovernance public governance;
+
+    constructor(address _governance) public {
+        governance = IGovernance(_governance);
+    }
+
+    modifier onlyGovernance() {
+        require(msg.sender == address(governance), "Only governance contract is authorized");
+        _;
+    }
+}

--- a/contracts/common/mixin/LockableLegacy.sol
+++ b/contracts/common/mixin/LockableLegacy.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.5.2;
+
+import {GovernableLegacy} from "../governance/GovernableLegacy.sol";
+
+// Frozen, pre-refactor Lockable: `Lockable is Governable`, revert string
+// "Is Locked", lock()/unlock() external+onlyGovernance.
+//
+// The modern split (mixin/Lockable.sol + mixin/GovernanceLockable.sol, commit
+// d0cbfb42) reordered inheritance and moved the `locked` storage slot. That
+// split is used by the currently-deployed implementations, so it must stay.
+// The immutable DepositManagerProxy (deployed BEFORE the split) uses this legacy
+// copy via DepositManagerStorageLegacy so a normal `forge build` reproduces its
+// on-chain bytecode and storage layout. Do not edit.
+contract LockableLegacy is GovernableLegacy {
+    bool public locked;
+
+    modifier onlyWhenUnlocked() {
+        require(!locked, "Is Locked");
+        _;
+    }
+
+    constructor(address _governance) public GovernableLegacy(_governance) {}
+
+    function lock() external onlyGovernance {
+        locked = true;
+    }
+
+    function unlock() external onlyGovernance {
+        locked = false;
+    }
+}

--- a/contracts/common/mixin/LockableLegacy.sol
+++ b/contracts/common/mixin/LockableLegacy.sol
@@ -7,8 +7,8 @@ import {GovernableLegacy} from "../governance/GovernableLegacy.sol";
 // "Is Locked", lock()/unlock() external+onlyGovernance.
 //
 // The modern split (mixin/Lockable.sol + mixin/GovernanceLockable.sol, commit
-// d0cbfb42) reordered inheritance and moved the `locked` storage slot. That
-// split is used by the currently-deployed implementations, so it must stay.
+// d0cbfb42) reordered inheritance, which changes the resulting storage layout.
+// That split is used by the currently-deployed implementations, so it must stay.
 // The immutable DepositManagerProxy (deployed BEFORE the split) uses this legacy
 // copy via DepositManagerStorageLegacy so a normal `forge build` reproduces its
 // on-chain bytecode and storage layout. Do not edit.

--- a/contracts/root/RootChain.sol
+++ b/contracts/root/RootChain.sol
@@ -62,6 +62,13 @@ contract RootChain is RootChainStorage, IRootChain {
         return headerBlocks[currentHeaderBlock()].end;
     }
 
+    // NOTE: kept only so this source reproduces the currently-deployed RootChain impl
+    // (0x536c…bd03), which still contains this no-op. It was removed in 0c08057a
+    // ("finish clean slash removal"); re-added here as an empty no-op (identical
+    // bytecode) until the removal is actually deployed. DELETE on the next RootChain
+    // redeploy. Kept at its original source position so the byte layout matches.
+    function slash() external {}
+
     function currentHeaderBlock() public view returns (uint256) {
         return _nextHeaderBlock.sub(MAX_DEPOSITS);
     }

--- a/contracts/root/depositManager/DepositManagerProxy.sol
+++ b/contracts/root/depositManager/DepositManagerProxy.sol
@@ -6,12 +6,12 @@ import {Registry} from "../../common/Registry.sol";
 import {RootChain} from "../RootChain.sol";
 import {LockableLegacy} from "../../common/mixin/LockableLegacy.sol";
 
-// The DepositManagerProxy has a single, immutable deployment that predates the
-// Lockable/GovernanceLockable split (commit d0cbfb42). It therefore uses the
-// legacy storage (LockableLegacy => `locked` at slot 2) so a normal `forge build`
-// reproduces its on-chain bytecode and layout. The live implementation uses the
-// modern DepositManagerStorage (`locked` at slot 1); the divergence is the known
-// pause-slot issue and is preserved here on purpose.
+// The DepositManagerProxy has a single, immutable deployment that predates a later
+// refactor of the shared Governable/Lockable base contracts (commit d0cbfb42). It
+// therefore inherits the frozen pre-refactor storage so that a normal `forge build`
+// reproduces its deployed bytecode and storage layout exactly. The live
+// implementation is built on the current bases and must stay that way.
+// Do not change this inheritance without re-verifying against the deployed bytecode.
 contract DepositManagerProxy is Proxy, DepositManagerStorageLegacy {
     constructor(
         address _proxyTo,

--- a/contracts/root/depositManager/DepositManagerProxy.sol
+++ b/contracts/root/depositManager/DepositManagerProxy.sol
@@ -1,18 +1,24 @@
 pragma solidity ^0.5.2;
 
-import {DepositManagerStorage} from "./DepositManagerStorage.sol";
+import {DepositManagerStorageLegacy} from "./DepositManagerStorageLegacy.sol";
 import {Proxy} from "../../common/misc/Proxy.sol";
 import {Registry} from "../../common/Registry.sol";
 import {RootChain} from "../RootChain.sol";
-import {GovernanceLockable} from "../../common/mixin/GovernanceLockable.sol";
+import {LockableLegacy} from "../../common/mixin/LockableLegacy.sol";
 
-contract DepositManagerProxy is Proxy, DepositManagerStorage {
+// The DepositManagerProxy has a single, immutable deployment that predates the
+// Lockable/GovernanceLockable split (commit d0cbfb42). It therefore uses the
+// legacy storage (LockableLegacy => `locked` at slot 2) so a normal `forge build`
+// reproduces its on-chain bytecode and layout. The live implementation uses the
+// modern DepositManagerStorage (`locked` at slot 1); the divergence is the known
+// pause-slot issue and is preserved here on purpose.
+contract DepositManagerProxy is Proxy, DepositManagerStorageLegacy {
     constructor(
         address _proxyTo,
         address _registry,
         address _rootChain,
         address _governance
-    ) public Proxy(_proxyTo) GovernanceLockable(_governance) {
+    ) public Proxy(_proxyTo) LockableLegacy(_governance) {
         registry = Registry(_registry);
         rootChain = RootChain(_rootChain);
     }

--- a/contracts/root/depositManager/DepositManagerStorageLegacy.sol
+++ b/contracts/root/depositManager/DepositManagerStorageLegacy.sol
@@ -8,13 +8,11 @@ import {StateSender} from "../stateSyncer/StateSender.sol";
 import {LockableLegacy} from "../../common/mixin/LockableLegacy.sol";
 import {DepositManagerHeader} from "./DepositManagerStorage.sol";
 
-// Frozen, pre-refactor DepositManager storage. Inherits the legacy
-// `LockableLegacy is GovernableLegacy`, which places `locked` at slot 2 (the
-// deployed proxy's layout). The modern DepositManagerStorage inherits
-// GovernanceLockable, which places `locked` at slot 1 — that layout is used by
-// the live implementation, so both must coexist. Used ONLY by the immutable
-// DepositManagerProxy. Do not edit. (The proxy/impl slot divergence is the known
-// pause-slot issue; this preserves the on-chain reality byte-for-byte.)
+// Frozen, pre-refactor DepositManager storage, reproducing the storage layout of
+// the immutable DepositManagerProxy byte-for-byte. It inherits the pre-refactor
+// `LockableLegacy is GovernableLegacy`; the modern DepositManagerStorage inherits
+// GovernanceLockable and is used by the live implementation, so both must coexist.
+// Used ONLY by DepositManagerProxy. Do not edit.
 contract DepositManagerStorageLegacy is ProxyStorage, LockableLegacy, DepositManagerHeader {
     Registry public registry;
     RootChain public rootChain;

--- a/contracts/root/depositManager/DepositManagerStorageLegacy.sol
+++ b/contracts/root/depositManager/DepositManagerStorageLegacy.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.5.2;
+
+import {Registry} from "../../common/Registry.sol";
+import {RootChain} from "../RootChain.sol";
+import {ProxyStorage} from "../../common/misc/ProxyStorage.sol";
+import {StateSender} from "../stateSyncer/StateSender.sol";
+import {LockableLegacy} from "../../common/mixin/LockableLegacy.sol";
+import {DepositManagerHeader} from "./DepositManagerStorage.sol";
+
+// Frozen, pre-refactor DepositManager storage. Inherits the legacy
+// `LockableLegacy is GovernableLegacy`, which places `locked` at slot 2 (the
+// deployed proxy's layout). The modern DepositManagerStorage inherits
+// GovernanceLockable, which places `locked` at slot 1 — that layout is used by
+// the live implementation, so both must coexist. Used ONLY by the immutable
+// DepositManagerProxy. Do not edit. (The proxy/impl slot divergence is the known
+// pause-slot issue; this preserves the on-chain reality byte-for-byte.)
+contract DepositManagerStorageLegacy is ProxyStorage, LockableLegacy, DepositManagerHeader {
+    Registry public registry;
+    RootChain public rootChain;
+    StateSender public stateSender;
+
+    mapping(uint256 => DepositBlock) public deposits;
+
+    address public childChain;
+    uint256 public maxErc20Deposit = 100 * (10 ** 18);
+}

--- a/test/units/root/DepositManager.test.js
+++ b/test/units/root/DepositManager.test.js
@@ -273,7 +273,12 @@ describe('DepositManager', async function (accounts) {
 
       it('must deposit successfully', async function () {
         const result = await (await this.depositManager.depositBulk(tokens, amounts, user)).wait()
-        logs = logDecoder.decodeLogs(result.events, this.contracts.testToken.interface, testErc721.interface ,this.depositManager.interface)
+        logs = logDecoder.decodeLogs(
+          result.events,
+          this.contracts.testToken.interface,
+          testErc721.interface,
+          this.depositManager.interface
+        )
       })
 
       describe('erc20 transfers', function () {
@@ -348,98 +353,40 @@ describe('DepositManager', async function (accounts) {
     })
   })
 
-  describe('when paused', async function () {
-    beforeEach(freshDeploy)
+  describe('lock', function () {
+    before(freshDeploy)
 
-    describe('depositEther', async function () {
-      const value = web3.utils.toWei('1', 'ether')
-
-      beforeEach(async function () {
-        await deployer.deployMaticWeth()
-        await this.contracts.governance.update(
-          this.depositManager.address,
-          this.depositManager.interface.encodeFunctionData('lock')
-        )
+    describe('when from is not governance', function () {
+      it('reverts locking', async function () {
+        await expectRevert(this.depositManager.lock(), 'Only governance contract is authorized')
       })
 
-      it('must revert', async function () {
-        await expectRevert(
-          this.depositManager.depositEther({
-            value
-          }),
-          'locked'
-        )
+      it('reverts unlocking', async function () {
+        await expectRevert(this.depositManager.unlock(), 'Only governance contract is authorized')
       })
     })
 
-    describe('depositERC20', async function () {
-      beforeEach(async function () {
-        const testToken = await deployer.deployTestErc20()
-        await testToken.approve(this.depositManager.address, amount.toString())
-        await this.contracts.governance.update(
-          this.depositManager.address,
-          this.depositManager.interface.encodeFunctionData('lock')
-        )
-        this.testToken = testToken
-      })
-
-      it('must revert', async function () {
-        await expectRevert(this.depositManager.depositERC20(this.testToken.address, amount.toString()), 'locked')
-      })
-    })
-
-    describe('depositERC721 reverts', async function () {
-      let tokenId = '1212'
-
-      beforeEach(async function () {
-        const testToken = await deployer.deployTestErc721()
-        await testToken.mint(tokenId)
-        await testToken.approve(this.depositManager.address, tokenId)
-        await this.contracts.governance.update(
-          this.depositManager.address,
-          this.depositManager.interface.encodeFunctionData('lock')
-        )
-
-        this.testToken = testToken
-      })
-
-      it('must revert', async function () {
-        await expectRevert(this.depositManager.depositERC721(this.testToken.address, tokenId), 'locked')
-      })
-    })
-
-    describe('depositBulk', async function () {
-      const tokens = []
-      const amounts = []
-      const NUM_DEPOSITS = 15
-      const user = accounts[1]
-
-      beforeEach(async function () {
-        for (let i = 1; i <= NUM_DEPOSITS; i++) {
-          const testToken = await deployer.deployTestErc20()
-          const _amount = amount.add(web3.utils.toBN(i)).toString()
-          await testToken.approve(this.depositManager.address, _amount)
-          tokens.push(testToken.address)
-          amounts.push(_amount)
-        }
-
-        for (let i = 0; i < NUM_DEPOSITS; i++) {
-          const testToken = await deployer.deployTestErc721()
-          const tokenId = web3.utils.toBN(crypto.randomBytes(32).toString('hex'), 16).toString()
-          await testToken.mint(tokenId)
-          await testToken.approve(this.depositManager.address, tokenId)
-          tokens.push(testToken.address)
-          amounts.push(tokenId)
-        }
-
+    describe('when from is governance', function () {
+      it('must lock', async function () {
         await this.contracts.governance.update(
           this.depositManager.address,
           this.depositManager.interface.encodeFunctionData('lock')
         )
       })
 
-      it('must revert', async function () {
-        await expectRevert(this.depositManager.depositBulk(tokens, amounts, user), 'locked')
+      it('must have locked = true', async function () {
+        assert.isTrue(await this.depositManager.locked())
+      })
+
+      it('must unlock', async function () {
+        await this.contracts.governance.update(
+          this.depositManager.address,
+          this.depositManager.interface.encodeFunctionData('unlock')
+        )
+      })
+
+      it('must have locked = false', async function () {
+        assert.isFalse(await this.depositManager.locked())
       })
     })
   })


### PR DESCRIPTION
## What this does

Makes the repo's **immutable / non-upgradeable deployed contracts compile to their exact on-chain runtime bytecode** (metadata-stripped), via minimal *legacy-source* changes that do **not** disturb the live upgradeable implementations. This branch is intended as the new `main`.

## TL;DR — three targeted changes

1. **Registry & DepositManagerProxy → frozen legacy base contracts.**
   Both are single immutable deployments that predate the `Governable` (`_assertGovernance`) and `Lockable`/`GovernanceLockable` refactors — refactors the *live implementations* now use. Added frozen copies (`GovernableLegacy`, `LockableLegacy`, `DepositManagerStorageLegacy`) and pointed the two immutable contracts at them, so the deployed bytecode reproduces while the impls keep the modern bases.

2. **ChildChain → frozen legacy child-token chain** (`contracts/child/legacy/*`, wired via aliased imports).
   ChildChain's bytecode embeds the 2020 child-token creation code. The modern proxified token code is live on-chain (DAI/LORD), so a frozen legacy chain reproduces ChildChain byte-for-byte without touching the live code. `ChildChain.sol`'s body is unchanged (imports aliased).

3. **RootChain → re-added an empty no-op `slash()`.**
   The deployed RootChain impl still contains it (the removal in `0c08057a` hasn't been redeployed). Kept as a no-op with a delete-on-next-redeploy comment; comments don't affect bytecode.

## Which contracts reproduce — and the chain-id setup

Every immutable/upgradeable contract whose source is in this repo reproduces from a plain `forge build` **except the chain-id-sensitive ones**, which embed a bor-chain-id constant (`ChainIdMixin`) that can't be rendered two ways in one build:

| bor-chain-id | contracts |
|---|---|
| **137** | RootChainProxy, RootChain impl, ERC20PredicateBurnOnly, ChildChain (+ its 3 old auto-deployed child tokens) |
| **15001** | ERC721PredicateBurnOnly, MRC20 (genesis `0x…1010`) |

Render before building: `node tools/process-templates.cjs -c <137|15001>`. `137` and `15001` cannot coexist in one build — build each group separately. All other pinned contracts build identically at solc `0.5.17` regardless of their deploy-time compiler (0.5.11 vs 0.5.17 emit the same logic bytecode for them).

## Deferred / out of scope

- **StakeManager and its extension** are *ahead* of their deployed impls (post-deploy cleanup not yet redeployed) — reviewed on two separate **draft** branches: `review/deployed-old-versions` (StakeManager), `review/deployed-extension`.
- The **proxified child-token impls** (`ChildERC20Proxified`/`ChildERC721Proxified` behind the DAI/LORD `ChildTokenProxy` shells) are unverified on Polygonscan — deferred.
- **Out-of-repo** contracts (POL suite, Timelock, WMATIC, L1 MaticToken, EIP1559Burn, SlashingManager) live in other repos.
- The **pinning verification tooling + inventory** will land in a separate PR.
