### PR TITLE
[DO NOT MERGE] StakeManager — revert to deployed impl for bytecode review

### DIFF
--- a/contracts/staking/stakeManager/IStakeManager.sol
+++ b/contracts/staking/stakeManager/IStakeManager.sol
@@ -1,13 +1,39 @@
 pragma solidity 0.5.17;
 
 contract IStakeManager {
-    function transferFunds(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    // validator replacement
+    function startAuction(
+        uint256 validatorId,
+        uint256 amount,
+        bool acceptDelegation,
+        bytes calldata signerPubkey
+    ) external;
 
-    function transferFundsPOL(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    function confirmAuctionBid(uint256 validatorId, uint256 heimdallFee) external;
 
-    function delegationDeposit(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    function transferFunds(
+        uint256 validatorId,
+        uint256 amount,
+        address delegator
+    ) external returns (bool);
 
-    function delegationDepositPOL(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    function transferFundsPOL(
+        uint256 validatorId, 
+        uint256 amount, 
+        address delegator
+    ) external returns (bool);
+
+    function delegationDeposit(
+        uint256 validatorId,
+        uint256 amount,
+        address delegator
+    ) external returns (bool);
+
+    function delegationDepositPOL(
+        uint256 validatorId, 
+        uint256 amount, 
+        address delegator
+    ) external returns (bool);
 
     function unstake(uint256 validatorId) external;
 
@@ -36,12 +62,14 @@ contract IStakeManager {
         bytes32 voteHash,
         bytes32 stateRoot,
         address proposer,
-        uint256[3][] calldata sigs
+        uint[3][] calldata sigs
     ) external returns (uint256);
 
     function updateValidatorState(uint256 validatorId, int256 amount) public;
 
     function ownerOf(uint256 tokenId) public view returns (address);
+
+    function slash(bytes calldata slashingInfoList) external returns (uint256);
 
     function validatorStake(uint256 validatorId) public view returns (uint256);
 
@@ -51,11 +79,20 @@ contract IStakeManager {
 
     function withdrawalDelay() public view returns (uint256);
 
-    function delegatedAmount(uint256 validatorId) public view returns (uint256);
+    function delegatedAmount(uint256 validatorId) public view returns(uint256);
 
     function decreaseValidatorDelegatedAmount(uint256 validatorId, uint256 amount) public;
 
-    function withdrawDelegatorsReward(uint256 validatorId) public returns (uint256);
+    function withdrawDelegatorsReward(uint256 validatorId) public returns(uint256);
 
-    function delegatorsReward(uint256 validatorId) public view returns (uint256);
+    function delegatorsReward(uint256 validatorId) public view returns(uint256);
+
+    function dethroneAndStake(
+        address auctionUser,
+        uint256 heimdallFee,
+        uint256 validatorId,
+        uint256 auctionAmount,
+        bool acceptDelegation,
+        bytes calldata signerPubkey
+    ) external;
 }

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -8,8 +8,10 @@ import {ECVerify} from "../../common/lib/ECVerify.sol";
 import {Merkle} from "../../common/lib/Merkle.sol";
 import {GovernanceLockable} from "../../common/mixin/GovernanceLockable.sol";
 import {DelegateProxyForwarder} from "../../common/misc/DelegateProxyForwarder.sol";
+import {Registry} from "../../common/Registry.sol";
 import {IStakeManager} from "./IStakeManager.sol";
 import {IValidatorShare} from "../validatorShare/IValidatorShare.sol";
+import {ValidatorShare} from "../validatorShare/ValidatorShare.sol";
 import {StakingInfo} from "../StakingInfo.sol";
 import {StakingNFT} from "./StakingNFT.sol";
 import {ValidatorShareFactory} from "../validatorShare/ValidatorShareFactory.sol";
@@ -69,42 +71,63 @@ contract StakeManager is
     function initialize(
         address _registry,
         address _rootchain,
-        address _tokenLegacy,
+        address _token,
         address _NFTContract,
         address _stakingLogger,
         address _validatorShareFactory,
         address _governance,
         address _owner,
-        address _extensionCode,
-        address _token,
-        address _migration
+        address _extensionCode
     ) external initializer {
-        require(isContract(_extensionCode), "extension impl incorrect");
+        require(isContract(_extensionCode), "auction impl incorrect");
         extensionCode = _extensionCode;
         governance = IGovernance(_governance);
         registry = _registry;
         rootChain = _rootchain;
         token = IERC20(_token);
-        tokenMatic = IERC20(_tokenLegacy);
-        migration = IPolygonMigration(_migration);
         NFTContract = StakingNFT(_NFTContract);
         logger = StakingInfo(_stakingLogger);
         validatorShareFactory = ValidatorShareFactory(_validatorShareFactory);
         _transferOwnership(_owner);
 
-        WITHDRAWAL_DELAY = (2 ** 13); // unit: epoch
+        WITHDRAWAL_DELAY = (2**13); // unit: epoch
         currentEpoch = 1;
         dynasty = 886; // unit: epoch 50 days
-        CHECKPOINT_REWARD = 20_188 * (10 ** 18); // update via governance
-        minDeposit = (10 ** 18); // in ERC20 token
-        minHeimdallFee = (10 ** 18); // in ERC20 token
+        CHECKPOINT_REWARD = 20188 * (10**18); // update via governance
+        minDeposit = (10**18); // in ERC20 token
+        minHeimdallFee = (10**18); // in ERC20 token
         checkPointBlockInterval = 1024;
         signerUpdateLimit = 100;
 
         validatorThreshold = 7; //128
         NFTCounter = 1;
+        auctionPeriod = (2**13) / 4; // 1 week in epochs
         proposerBonus = 10; // 10 % of total rewards
         delegationEnabled = true;
+    }
+
+    function reinitialize(
+        address _NFTContract,
+        address _stakingLogger,
+        address _validatorShareFactory,
+        address _extensionCode
+    ) external onlyGovernance {
+        require(isContract(_extensionCode));
+        eventsHub = address(0x0);
+        extensionCode = _extensionCode;
+        NFTContract = StakingNFT(_NFTContract);
+        logger = StakingInfo(_stakingLogger);
+        validatorShareFactory = ValidatorShareFactory(_validatorShareFactory);
+    }
+
+    function initializePOL(
+        address _tokenNew,
+        address _migration
+    ) external onlyGovernance {
+        tokenMatic = IERC20(token);
+        token = IERC20(_tokenNew);
+        migration = IPolygonMigration(_migration);
+        _convertMaticToPOL(tokenMatic.balanceOf(address(this)));
     }
 
     function isOwner() public view returns (bool) {
@@ -117,14 +140,15 @@ contract StakeManager is
     }
 
     /**
-     * Public View Methods
+        Public View Methods
      */
+
     function getRegistry() public view returns (address) {
         return registry;
     }
 
     /**
-     * @dev Owner of validator slot NFT
+        @dev Owner of validator slot NFT
      */
     function ownerOf(uint256 tokenId) public view returns (address) {
         return NFTContract.ownerOf(tokenId);
@@ -161,7 +185,7 @@ contract StakeManager is
     function validatorReward(uint256 validatorId) public view returns (uint256) {
         uint256 _validatorReward;
         if (validators[validatorId].deactivationEpoch == 0) {
-            (_validatorReward,) = _evaluateValidatorAndDelegationReward(validatorId);
+            (_validatorReward, ) = _evaluateValidatorAndDelegationReward(validatorId);
         }
         return validators[validatorId].reward.add(_validatorReward).sub(INITIALIZED_AMOUNT);
     }
@@ -179,17 +203,19 @@ contract StakeManager is
     }
 
     function isValidator(uint256 validatorId) public view returns (bool) {
-        return _isValidator(
-            validators[validatorId].status,
-            validators[validatorId].amount,
-            validators[validatorId].deactivationEpoch,
-            currentEpoch
-        );
+        return
+            _isValidator(
+                validators[validatorId].status,
+                validators[validatorId].amount,
+                validators[validatorId].deactivationEpoch,
+                currentEpoch
+            );
     }
 
     /**
-     * Governance Methods
+        Governance Methods
      */
+
     function setDelegationEnabled(bool enabled) public onlyGovernance {
         delegationEnabled = enabled;
     }
@@ -205,6 +231,11 @@ contract StakeManager is
 
     function setCurrentEpoch(uint256 _currentEpoch) external onlyGovernance {
         currentEpoch = _currentEpoch;
+    }
+
+    function setStakingToken(address _token) public onlyGovernance {
+        require(_token != address(0x0));
+        token = IERC20(_token);
     }
 
     /**
@@ -249,7 +280,9 @@ contract StakeManager is
         delegatedFwd(
             extensionCode,
             abi.encodeWithSelector(
-                StakeManagerExtension(extensionCode).migrateValidatorsData.selector, validatorIdFrom, validatorIdTo
+                StakeManagerExtension(extensionCode).migrateValidatorsData.selector,
+                validatorIdFrom,
+                validatorIdTo
             )
         );
     }
@@ -259,7 +292,7 @@ contract StakeManager is
     }
 
     /**
-     * @dev Users must exit before this update or all funds may get lost
+        @dev Users must exit before this update or all funds may get lost
      */
     function updateValidatorContractAddress(uint256 validatorId, address newContractAddress) public onlyGovernance {
         require(IValidatorShare(newContractAddress).owner() == address(this));
@@ -271,6 +304,13 @@ contract StakeManager is
         logger.logDynastyValueChange(newDynasty, dynasty);
         dynasty = newDynasty;
         WITHDRAWAL_DELAY = newDynasty;
+        auctionPeriod = newDynasty.div(4);
+        replacementCoolDown = currentEpoch.add(auctionPeriod);
+    }
+
+    // Housekeeping function. @todo remove later
+    function stopAuctions(uint256 forNCheckpoints) public onlyGovernance {
+        replacementCoolDown = currentEpoch.add(forNCheckpoints);
     }
 
     function updateProposerBonus(uint256 newProposerBonus) public onlyGovernance {
@@ -289,17 +329,14 @@ contract StakeManager is
     }
 
     /**
-     * Public Methods
+        Public Methods
      */
     function topUpForFee(address user, uint256 heimdallFee) public onlyWhenUnlocked {
         _transferAndTopUp(user, msg.sender, heimdallFee, 0, true);
     }
 
     function claimFee(uint256 accumFeeAmount, uint256 index, bytes memory proof) public {
-        require(
-            keccak256(abi.encode(msg.sender, accumFeeAmount)).checkMembership(index, accountStateRoot, proof),
-            "Wrong acc proof"
-        );
+        require(keccak256(abi.encode(msg.sender, accumFeeAmount)).checkMembership(index, accountStateRoot, proof), "Wrong acc proof");
         uint256 withdrawAmount = accumFeeAmount.sub(userFeeExit[msg.sender]);
         totalHeimdallFee = totalHeimdallFee.sub(withdrawAmount);
         logger.logClaimFee(msg.sender, withdrawAmount);
@@ -314,6 +351,56 @@ contract StakeManager is
         return validators[NFTContract.tokenOfOwnerByIndex(user, 0)].amount;
     }
 
+    function startAuction(
+        uint256 validatorId,
+        uint256 amount,
+        bool _acceptDelegation,
+        bytes calldata _signerPubkey
+    ) external onlyWhenUnlocked {
+        delegatedFwd(
+            extensionCode,
+            abi.encodeWithSelector(
+                StakeManagerExtension(extensionCode).startAuction.selector,
+                validatorId,
+                amount,
+                _acceptDelegation,
+                _signerPubkey
+            )
+        );
+    }
+
+    function confirmAuctionBid(
+        uint256 validatorId,
+        uint256 heimdallFee /** for new validator */
+    ) external onlyWhenUnlocked {
+        delegatedFwd(
+            extensionCode,
+            abi.encodeWithSelector(
+                StakeManagerExtension(extensionCode).confirmAuctionBid.selector,
+                validatorId,
+                heimdallFee,
+                address(this)
+            )
+        );
+    }
+
+    function dethroneAndStake(
+        address auctionUser,
+        uint256 heimdallFee,
+        uint256 validatorId,
+        uint256 auctionAmount,
+        bool acceptDelegation,
+        bytes calldata signerPubkey
+    ) external {
+        require(msg.sender == address(this), "not allowed");
+        // dethrone
+        _transferAndTopUp(auctionUser, auctionUser, heimdallFee, 0, true);
+        _unstake(validatorId, currentEpoch, true);
+
+        uint256 newValidatorId = _stakeFor(auctionUser, auctionAmount, acceptDelegation, signerPubkey);
+        logger.logConfirmAuction(newValidatorId, validatorId, auctionAmount);
+    }
+
     function unstake(uint256 validatorId) external onlyStaker(validatorId) {
         _unstakeValidator(validatorId, false);
     }
@@ -323,10 +410,13 @@ contract StakeManager is
     }
 
     function _unstakeValidator(uint256 validatorId, bool pol) internal {
+        require(validatorAuction[validatorId].amount == 0);
+
         Status status = validators[validatorId].status;
         require(
-            validators[validatorId].activationEpoch > 0 && validators[validatorId].deactivationEpoch == 0
-                && (status == Status.Active || status == Status.Locked)
+            validators[validatorId].activationEpoch > 0 &&
+                validators[validatorId].deactivationEpoch == 0 &&
+                (status == Status.Active || status == Status.Locked)
         );
 
         uint256 exitEpoch = currentEpoch.add(1); // notice period
@@ -342,25 +432,17 @@ contract StakeManager is
     }
 
     function _transferFunds(uint256 validatorId, uint256 amount, address delegator, bool pol) internal returns (bool) {
-        require(validators[validatorId].contractAddress == msg.sender, "not allowed");
+        require(validators[validatorId].contractAddress == msg.sender || Registry(registry).getSlashingManagerAddress() == msg.sender, "not allowed");
         if (!pol) _convertPOLToMatic(amount);
         IERC20 token_ = _getToken(pol);
         return token_.transfer(delegator, amount);
     }
 
-    function delegationDeposit(
-        uint256 validatorId,
-        uint256 amount,
-        address delegator
-    ) external onlyDelegation(validatorId) returns (bool) {
+    function delegationDeposit(uint256 validatorId, uint256 amount, address delegator) external onlyDelegation(validatorId) returns (bool) {
         return _delegationDeposit(amount, delegator, false);
     }
 
-    function delegationDepositPOL(
-        uint256 validatorId,
-        uint256 amount,
-        address delegator
-    ) external onlyDelegation(validatorId) returns (bool) {
+    function delegationDepositPOL(uint256 validatorId, uint256 amount, address delegator) external onlyDelegation(validatorId) returns (bool) {
         return _delegationDeposit(amount, delegator, true);
     }
 
@@ -371,34 +453,15 @@ contract StakeManager is
         return result;
     }
 
-    function stakeFor(
-        address user,
-        uint256 amount,
-        uint256 heimdallFee,
-        bool acceptDelegation,
-        bytes memory signerPubkey
-    ) public onlyWhenUnlocked {
+    function stakeFor(address user, uint256 amount, uint256 heimdallFee, bool acceptDelegation, bytes memory signerPubkey) public onlyWhenUnlocked {
         _stakeFor(user, amount, heimdallFee, acceptDelegation, signerPubkey, false);
     }
 
-    function stakeForPOL(
-        address user,
-        uint256 amount,
-        uint256 heimdallFee,
-        bool acceptDelegation,
-        bytes memory signerPubkey
-    ) public onlyWhenUnlocked {
+    function stakeForPOL(address user, uint256 amount, uint256 heimdallFee, bool acceptDelegation, bytes memory signerPubkey) public onlyWhenUnlocked {
         _stakeFor(user, amount, heimdallFee, acceptDelegation, signerPubkey, true);
     }
 
-    function _stakeFor(
-        address user,
-        uint256 amount,
-        uint256 heimdallFee,
-        bool acceptDelegation,
-        bytes memory signerPubkey,
-        bool pol
-    ) internal {
+    function _stakeFor(address user, uint256 amount, uint256 heimdallFee, bool acceptDelegation, bytes memory signerPubkey, bool pol) internal {
         require(currentValidatorSetSize() < validatorThreshold, "no more slots");
         require(amount >= minDeposit, "not enough deposit");
         _transferAndTopUp(user, msg.sender, heimdallFee, amount, pol);
@@ -417,8 +480,9 @@ contract StakeManager is
         uint256 deactivationEpoch = validators[validatorId].deactivationEpoch;
         // can only claim stake back after WITHDRAWAL_DELAY
         require(
-            deactivationEpoch > 0 && deactivationEpoch.add(WITHDRAWAL_DELAY) <= currentEpoch
-                && validators[validatorId].status != Status.Unstaked
+            deactivationEpoch > 0 &&
+                deactivationEpoch.add(WITHDRAWAL_DELAY) <= currentEpoch &&
+                validators[validatorId].status != Status.Unstaked
         );
 
         uint256 amount = validators[validatorId].amount;
@@ -441,19 +505,11 @@ contract StakeManager is
         logger.logUnstaked(msg.sender, validatorId, amount, newTotalStaked);
     }
 
-    function restake(
-        uint256 validatorId,
-        uint256 amount,
-        bool stakeRewards
-    ) public onlyWhenUnlocked onlyStaker(validatorId) {
+    function restake(uint256 validatorId, uint256 amount, bool stakeRewards) public onlyWhenUnlocked onlyStaker(validatorId) {
         _restake(validatorId, amount, stakeRewards, false);
     }
 
-    function restakePOL(
-        uint256 validatorId,
-        uint256 amount,
-        bool stakeRewards
-    ) public onlyWhenUnlocked onlyStaker(validatorId) {
+    function restakePOL(uint256 validatorId, uint256 amount, bool stakeRewards) public onlyWhenUnlocked onlyStaker(validatorId) {
         _restake(validatorId, amount, stakeRewards, true);
     }
 
@@ -494,7 +550,11 @@ contract StakeManager is
         _liquidateRewards(validatorId, msg.sender, pol);
     }
 
-    function migrateDelegation(uint256 fromValidatorId, uint256 toValidatorId, uint256 amount) public {
+    function migrateDelegation(
+        uint256 fromValidatorId,
+        uint256 toValidatorId,
+        uint256 amount
+    ) public {
         // allow to move to any non-foundation node
         require(toValidatorId > 7, "Invalid migration");
         IValidatorShare(validators[fromValidatorId].contractAddress).migrateOut(msg.sender, amount);
@@ -509,13 +569,12 @@ contract StakeManager is
 
         uint256 deactivationEpoch = validators[validatorId].deactivationEpoch;
 
-        if (deactivationEpoch == 0) {
-            // modify timeline only if validator didn't unstake
+        if (deactivationEpoch == 0) { // modify timeline only if validator didn't unstake
             updateTimeline(amount, 0, 0);
-        } else if (deactivationEpoch > currentEpoch) {
-            // validator just unstaked, need to wait till next checkpoint
+        } else if (deactivationEpoch > currentEpoch) { // validator just unstaked, need to wait till next checkpoint
             revert("unstaking");
         }
+        
 
         if (amount >= 0) {
             increaseValidatorDelegatedAmount(validatorId, uint256(amount));
@@ -540,8 +599,8 @@ contract StakeManager is
         address currentSigner = validators[validatorId].signer;
         // update signer event
         logger.logSignerChange(validatorId, currentSigner, signer, signerPubkey);
-
-        if (validators[validatorId].deactivationEpoch == 0) {
+        
+        if (validators[validatorId].deactivationEpoch == 0) { 
             // didn't unstake, swap signer in the list
             _removeSigner(currentSigner);
             _insertSigner(signer);
@@ -618,16 +677,17 @@ contract StakeManager is
         // find the rest of validators without signature
         unsignedCtx = _fillUnsignedValidators(unsignedCtx, address(0));
 
-        return _increaseRewardAndAssertConsensus(
-            blockInterval,
-            proposer,
-            signedStakePower,
-            stateRoot,
-            unsignedCtx.unsignedValidators,
-            unsignedCtx.unsignedValidatorIndex,
-            unstakeCtx.deactivatedValidators,
-            unstakeCtx.validatorIndex
-        );
+        return
+            _increaseRewardAndAssertConsensus(
+                blockInterval,
+                proposer,
+                signedStakePower,
+                stateRoot,
+                unsignedCtx.unsignedValidators,
+                unsignedCtx.unsignedValidatorIndex,
+                unstakeCtx.deactivatedValidators,
+                unstakeCtx.validatorIndex
+            );
     }
 
     function updateCommissionRate(uint256 validatorId, uint256 newCommissionRate) external onlyStaker(validatorId) {
@@ -636,7 +696,9 @@ contract StakeManager is
         delegatedFwd(
             extensionCode,
             abi.encodeWithSelector(
-                StakeManagerExtension(extensionCode).updateCommissionRate.selector, validatorId, newCommissionRate
+                StakeManagerExtension(extensionCode).updateCommissionRate.selector,
+                validatorId,
+                newCommissionRate
             )
         );
     }
@@ -649,7 +711,39 @@ contract StakeManager is
         return totalReward;
     }
 
-    function updateTimeline(int256 amount, int256 stakerCount, uint256 targetEpoch) internal {
+    function slash(bytes calldata _slashingInfoList) external returns (uint256) {
+        revert();
+    }
+
+    function unjail(uint256 validatorId) public onlyStaker(validatorId) {
+        require(validators[validatorId].status == Status.Locked, "Not jailed");
+        require(validators[validatorId].deactivationEpoch == 0, "Already unstaking");
+
+        uint256 _currentEpoch = currentEpoch;
+        require(validators[validatorId].jailTime <= _currentEpoch, "Incomplete jail period");
+
+        uint256 amount = validators[validatorId].amount;
+        require(amount >= minDeposit);
+
+        address delegationContract = validators[validatorId].contractAddress;
+        if (delegationContract != address(0x0)) {
+            IValidatorShare(delegationContract).unlock();
+        }
+
+        // undo timeline so that validator is normal validator
+        updateTimeline(int256(amount.add(validators[validatorId].delegatedAmount)), 1, 0);
+
+        validators[validatorId].status = Status.Active;
+
+        address signer = validators[validatorId].signer;
+        logger.logUnjailed(validatorId, signer);
+    }
+
+    function updateTimeline(
+        int256 amount,
+        int256 stakerCount,
+        uint256 targetEpoch
+    ) internal {
         if (targetEpoch == 0) {
             // update total stake and validator count
             if (amount > 0) {
@@ -688,8 +782,9 @@ contract StakeManager is
     }
 
     /**
-     * Private Methods
+        Private Methods
      */
+
     function _getAndAssertSigner(bytes memory pub) private view returns (address) {
         require(pub.length == 64, "not pub");
         address signer = address(uint160(uint256(keccak256(pub))));
@@ -706,14 +801,13 @@ contract StakeManager is
         return (amount > 0 && (deactivationEpoch == 0 || deactivationEpoch > _currentEpoch) && status == Status.Active);
     }
 
-    function _fillUnsignedValidators(
-        UnsignedValidatorsContext memory context,
-        address signer
-    ) private view returns (UnsignedValidatorsContext memory) {
-        while (context.validatorIndex < context.totalValidators && context.validators[context.validatorIndex] != signer)
-        {
-            context.unsignedValidators[context.unsignedValidatorIndex] =
-                signerToValidator[context.validators[context.validatorIndex]];
+    function _fillUnsignedValidators(UnsignedValidatorsContext memory context, address signer)
+        private
+        view
+        returns(UnsignedValidatorsContext memory)
+    {
+        while (context.validatorIndex < context.totalValidators && context.validators[context.validatorIndex] != signer) {
+            context.unsignedValidators[context.unsignedValidatorIndex] = signerToValidator[context.validators[context.validatorIndex]];
             context.unsignedValidatorIndex++;
             context.validatorIndex++;
         }
@@ -743,7 +837,7 @@ contract StakeManager is
             if (prevBlockInterval != 0) {
                 // give more reward for faster and less for slower checkpoint
                 uint256 delta = (ckpReward * checkpointRewardDelta / CHK_REWARD_PRECISION);
-
+                
                 if (prevBlockInterval > fullIntervals) {
                     // checkpoint is faster
                     ckpReward += delta;
@@ -751,7 +845,7 @@ contract StakeManager is
                     ckpReward -= delta;
                 }
             }
-
+            
             prevBlockInterval = fullIntervals;
         }
 
@@ -762,16 +856,11 @@ contract StakeManager is
             uint256 _rewardDecreasePerCheckpoint = rewardDecreasePerCheckpoint;
 
             // calculate reward for full intervals
-            reward = ckpReward.mul(fullIntervals).sub(
-                ckpReward.mul(((fullIntervals - 1) * fullIntervals / 2).mul(_rewardDecreasePerCheckpoint)).div(
-                    CHK_REWARD_PRECISION
-                )
-            );
+            reward = ckpReward.mul(fullIntervals).sub(ckpReward.mul(((fullIntervals - 1) * fullIntervals / 2).mul(_rewardDecreasePerCheckpoint)).div(CHK_REWARD_PRECISION));
             // adjust block interval, in case last interval is not full
             blockInterval = blockInterval.sub(fullIntervals.mul(targetBlockInterval));
             // adjust checkpoint reward by the amount it suppose to decrease
-            ckpReward =
-                ckpReward.sub(ckpReward.mul(fullIntervals).mul(_rewardDecreasePerCheckpoint).div(CHK_REWARD_PRECISION));
+            ckpReward = ckpReward.sub(ckpReward.mul(fullIntervals).mul(_rewardDecreasePerCheckpoint).div(CHK_REWARD_PRECISION));
         }
 
         // give proportionally less for the rest
@@ -807,15 +896,13 @@ contract StakeManager is
         uint256 newRewardPerStake =
             rewardPerStake.add(reward.sub(_proposerBonus).mul(REWARD_PRECISION).div(signedStakePower));
 
-        // evaluate rewards for validator who did't sign and set latest reward per stake to new value to avoid them from
-        // getting new rewards.
+        // evaluate rewards for validator who did't sign and set latest reward per stake to new value to avoid them from getting new rewards.
         _updateValidatorsRewards(unsignedValidators, totalUnsignedValidators, newRewardPerStake);
 
         // distribute rewards between signed validators
         rewardPerStake = newRewardPerStake;
 
-        // evaluate rewards for unstaked validators to ensure they get the reward for signing during their
-        // deactivationEpoch
+        // evaluate rewards for unstaked validators to ensure they get the reward for signing during their deactivationEpoch
         _updateValidatorsRewards(deactivatedValidators, totalDeactivatedValidators, newRewardPerStake);
 
         _finalizeCommit();
@@ -848,19 +935,29 @@ contract StakeManager is
         // attempt to save gas in case if rewards were updated previously
         if (initialRewardPerStake < currentRewardPerStake) {
             uint256 validatorsStake = validators[validatorId].amount;
-            uint256 valDelegatedAmount = validators[validatorId].delegatedAmount;
-            if (valDelegatedAmount > 0) {
-                uint256 combinedStakePower = validatorsStake.add(valDelegatedAmount);
+            uint256 delegatedAmount = validators[validatorId].delegatedAmount;
+            if (delegatedAmount > 0) {
+                uint256 combinedStakePower = validatorsStake.add(delegatedAmount);
                 _increaseValidatorRewardWithDelegation(
                     validatorId,
                     validatorsStake,
-                    valDelegatedAmount,
-                    _getEligibleValidatorReward(combinedStakePower, currentRewardPerStake, initialRewardPerStake)
+                    delegatedAmount,
+                    _getEligibleValidatorReward(
+                        validatorId,
+                        combinedStakePower,
+                        currentRewardPerStake,
+                        initialRewardPerStake
+                    )
                 );
             } else {
                 _increaseValidatorReward(
                     validatorId,
-                    _getEligibleValidatorReward(validatorsStake, currentRewardPerStake, initialRewardPerStake)
+                    _getEligibleValidatorReward(
+                        validatorId,
+                        validatorsStake,
+                        currentRewardPerStake,
+                        initialRewardPerStake
+                    )
                 );
             }
         }
@@ -875,6 +972,7 @@ contract StakeManager is
     }
 
     function _getEligibleValidatorReward(
+        uint256 validatorId,
         uint256 validatorStakePower,
         uint256 currentRewardPerStake,
         uint256 initialRewardPerStake
@@ -892,19 +990,19 @@ contract StakeManager is
     function _increaseValidatorRewardWithDelegation(
         uint256 validatorId,
         uint256 validatorsStake,
-        uint256 valDelegatedAmount,
+        uint256 delegatedAmount,
         uint256 reward
     ) private {
-        uint256 combinedStakePower = valDelegatedAmount.add(validatorsStake);
-        (uint256 valReward, uint256 delReward) =
+        uint256 combinedStakePower = delegatedAmount.add(validatorsStake);
+        (uint256 validatorReward, uint256 delegatorsReward) =
             _getValidatorAndDelegationReward(validatorId, validatorsStake, reward, combinedStakePower);
 
-        if (delReward > 0) {
-            validators[validatorId].delegatorsReward = validators[validatorId].delegatorsReward.add(delReward);
+        if (delegatorsReward > 0) {
+            validators[validatorId].delegatorsReward = validators[validatorId].delegatorsReward.add(delegatorsReward);
         }
 
-        if (valReward > 0) {
-            validators[validatorId].reward = validators[validatorId].reward.add(valReward);
+        if (validatorReward > 0) {
+            validators[validatorId].reward = validators[validatorId].reward.add(validatorReward);
         }
     }
 
@@ -918,32 +1016,35 @@ contract StakeManager is
             return (0, 0);
         }
 
-        uint256 valReward = validatorsStake.mul(reward).div(combinedStakePower);
+        uint256 validatorReward = validatorsStake.mul(reward).div(combinedStakePower);
 
         // add validator commission from delegation reward
         uint256 commissionRate = validators[validatorId].commissionRate;
         if (commissionRate > 0) {
-            valReward = valReward.add(reward.sub(valReward).mul(commissionRate).div(MAX_COMMISION_RATE));
+            validatorReward = validatorReward.add(
+                reward.sub(validatorReward).mul(commissionRate).div(MAX_COMMISION_RATE)
+            );
         }
 
-        uint256 delReward = reward.sub(valReward);
-        return (valReward, delReward);
+        uint256 delegatorsReward = reward.sub(validatorReward);
+        return (validatorReward, delegatorsReward);
     }
 
     function _evaluateValidatorAndDelegationReward(uint256 validatorId)
         private
         view
-        returns (uint256 valReward, uint256 delReward)
+        returns (uint256 validatorReward, uint256 delegatorsReward)
     {
         uint256 validatorsStake = validators[validatorId].amount;
         uint256 combinedStakePower = validatorsStake.add(validators[validatorId].delegatedAmount);
         uint256 eligibleReward = rewardPerStake - validators[validatorId].initialRewardPerStake;
-        return _getValidatorAndDelegationReward(
-            validatorId,
-            validatorsStake,
-            eligibleReward.mul(combinedStakePower).div(REWARD_PRECISION),
-            combinedStakePower
-        );
+        return
+            _getValidatorAndDelegationReward(
+                validatorId,
+                validatorsStake,
+                eligibleReward.mul(combinedStakePower).div(REWARD_PRECISION),
+                combinedStakePower
+            );
     }
 
     function _stakeFor(
@@ -983,6 +1084,8 @@ contract StakeManager is
 
         signerToValidator[signer] = validatorId;
         updateTimeline(int256(amount), 1, 0);
+        // no Auctions for 1 dynasty
+        validatorAuction[validatorId].startEpoch = _currentEpoch;
         _logger.logStaked(signer, signerPubkey, validatorId, _currentEpoch, amount, newTotalStaked);
         NFTCounter = validatorId.add(1);
 

--- a/contracts/staking/stakeManager/StakeManagerExtension.sol
+++ b/contracts/staking/stakeManager/StakeManagerExtension.sol
@@ -1,10 +1,13 @@
 pragma solidity 0.5.17;
 
+import {IERC20} from "../../common/oz/token/ERC20/IERC20.sol";
 import {SafeMath} from "../../common/oz/math/SafeMath.sol";
 import {Registry} from "../../common/Registry.sol";
 import {GovernanceLockable} from "../../common/mixin/GovernanceLockable.sol";
+import {IStakeManager} from "./IStakeManager.sol";
 import {StakeManagerStorage} from "./StakeManagerStorage.sol";
 import {StakeManagerStorageExtension} from "./StakeManagerStorageExtension.sol";
+import {Math} from "../../common/oz/math/Math.sol";
 import {Initializable} from "../../common/mixin/Initializable.sol";
 import {EventsHub} from "../EventsHub.sol";
 import {ValidatorShare} from "../validatorShare/ValidatorShare.sol";
@@ -14,7 +17,115 @@ contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManag
 
     constructor() public GovernanceLockable(address(0x0)) {}
 
-    function migrateValidatorsData(uint256 validatorIdFrom, uint256 validatorIdTo) external {
+    function startAuction(
+        uint256 validatorId,
+        uint256 amount,
+        bool _acceptDelegation,
+        bytes calldata _signerPubkey
+    ) external {
+        uint256 currentValidatorAmount = validators[validatorId].amount;
+
+        require(
+            validators[validatorId].deactivationEpoch == 0 && currentValidatorAmount != 0,
+            "Invalid validator for an auction"
+        );
+        uint256 senderValidatorId = signerToValidator[msg.sender];
+        // make sure that signer wasn't used already
+        require(
+            NFTContract.balanceOf(msg.sender) == 0 && // existing validators can't bid
+                senderValidatorId != INCORRECT_VALIDATOR_ID,
+            "Already used address"
+        );
+
+        uint256 _currentEpoch = currentEpoch;
+        uint256 _replacementCoolDown = replacementCoolDown;
+        // when dynasty period is updated validators are in cooldown period
+        require(_replacementCoolDown == 0 || _replacementCoolDown <= _currentEpoch, "Cooldown period");
+        // (auctionPeriod--dynasty)--(auctionPeriod--dynasty)--(auctionPeriod--dynasty)
+        // if it's auctionPeriod then will get residue smaller then auctionPeriod
+        // from (CurrentPeriod of validator )%(auctionPeriod--dynasty)
+        // make sure that its `auctionPeriod` window
+        // dynasty = 30, auctionPeriod = 7, activationEpoch = 1, currentEpoch = 39
+        // residue 1 = (39-1)% (7+30), if residue <= auctionPeriod it's `auctionPeriod`
+
+        require(
+            (_currentEpoch.sub(validators[validatorId].activationEpoch) % dynasty.add(auctionPeriod)) < auctionPeriod,
+            "Invalid auction period"
+        );
+
+        uint256 perceivedStake = currentValidatorAmount;
+        perceivedStake = perceivedStake.add(validators[validatorId].delegatedAmount);
+
+        Auction storage auction = validatorAuction[validatorId];
+        uint256 currentAuctionAmount = auction.amount;
+
+        perceivedStake = Math.max(perceivedStake, currentAuctionAmount);
+
+        require(perceivedStake < amount, "Must bid higher");
+        require(token.transferFrom(msg.sender, address(this), amount), "Transfer failed");
+
+        //replace prev auction
+        if (currentAuctionAmount != 0) {
+            require(token.transfer(auction.user, currentAuctionAmount), "Bid return failed");
+        }
+
+        // create new auction
+        auction.amount = amount;
+        auction.user = msg.sender;
+        auction.acceptDelegation = _acceptDelegation;
+        auction.signerPubkey = _signerPubkey;
+
+        logger.logStartAuction(validatorId, currentValidatorAmount, amount);
+    }
+
+    function confirmAuctionBid(
+        uint256 validatorId,
+        uint256 heimdallFee, /** for new validator */
+        IStakeManager stakeManager
+    ) external {
+        Auction storage auction = validatorAuction[validatorId];
+        address auctionUser = auction.user;
+
+        require(
+            msg.sender == auctionUser || NFTContract.tokenOfOwnerByIndex(msg.sender, 0) == validatorId,
+            "Only bidder can confirm"
+        );
+
+        uint256 _currentEpoch = currentEpoch;
+        require(
+            _currentEpoch.sub(auction.startEpoch) % auctionPeriod.add(dynasty) >= auctionPeriod,
+            "Not allowed before auctionPeriod"
+        );
+        require(auction.user != address(0x0), "Invalid auction");
+
+        uint256 validatorAmount = validators[validatorId].amount;
+        uint256 perceivedStake = validatorAmount;
+        uint256 auctionAmount = auction.amount;
+
+        perceivedStake = perceivedStake.add(validators[validatorId].delegatedAmount);
+
+        // validator is last auctioner
+        if (perceivedStake >= auctionAmount && validators[validatorId].deactivationEpoch == 0) {
+            require(token.transfer(auctionUser, auctionAmount), "Bid return failed");
+            //cleanup auction data
+            auction.startEpoch = _currentEpoch;
+            logger.logConfirmAuction(validatorId, validatorId, validatorAmount);
+        } else {
+            stakeManager.dethroneAndStake(
+                auctionUser, 
+                heimdallFee,
+                validatorId,
+                auctionAmount,
+                auction.acceptDelegation,
+                auction.signerPubkey
+            );
+        }
+        uint256 startEpoch = auction.startEpoch;
+        delete validatorAuction[validatorId];
+        validatorAuction[validatorId].startEpoch = startEpoch;
+    }
+
+    function migrateValidatorsData(uint256 validatorIdFrom, uint256 validatorIdTo) external {       
         for (uint256 i = validatorIdFrom; i < validatorIdTo; ++i) {
             ValidatorShare contractAddress = ValidatorShare(validators[i].contractAddress);
             if (contractAddress != ValidatorShare(0)) {
@@ -42,9 +153,7 @@ contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManag
         maxRewardedCheckpoints = _maxRewardedCheckpoints;
         checkpointRewardDelta = _checkpointRewardDelta;
 
-        _getOrCacheEventsHub().logRewardParams(
-            _rewardDecreasePerCheckpoint, _maxRewardedCheckpoints, _checkpointRewardDelta
-        );
+        _getOrCacheEventsHub().logRewardParams(_rewardDecreasePerCheckpoint, _maxRewardedCheckpoints, _checkpointRewardDelta);
     }
 
     function updateCommissionRate(uint256 validatorId, uint256 newCommissionRate) external {
@@ -52,20 +161,17 @@ contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManag
         uint256 _lastCommissionUpdate = validators[validatorId].lastCommissionUpdate;
 
         require( // withdrawalDelay == dynasty
-            (_lastCommissionUpdate.add(WITHDRAWAL_DELAY) <= _epoch) || _lastCommissionUpdate == 0, // For initial
-                // setting of commission rate
+            (_lastCommissionUpdate.add(WITHDRAWAL_DELAY) <= _epoch) || _lastCommissionUpdate == 0, // For initial setting of commission rate
             "Cooldown"
         );
 
         require(newCommissionRate <= MAX_COMMISION_RATE, "Incorrect value");
-        _getOrCacheEventsHub().logUpdateCommissionRate(
-            validatorId, newCommissionRate, validators[validatorId].commissionRate
-        );
+        _getOrCacheEventsHub().logUpdateCommissionRate(validatorId, newCommissionRate, validators[validatorId].commissionRate);
         validators[validatorId].commissionRate = newCommissionRate;
         validators[validatorId].lastCommissionUpdate = _epoch;
     }
 
-    function _getOrCacheEventsHub() private returns (EventsHub) {
+    function _getOrCacheEventsHub() private returns(EventsHub) {
         EventsHub _eventsHub = EventsHub(eventsHub);
         if (_eventsHub == EventsHub(0x0)) {
             _eventsHub = EventsHub(Registry(registry).contractMap(keccak256("eventsHub")));


### PR DESCRIPTION
> ⚠️ **DRAFT — DO NOT MERGE.** Review-only branch. It reverts a live contract to the version **currently deployed on-chain** so reviewers can diff the deployed code against `main`. **CI will be red** — the reverted StakeManager doesn't fit the current callers — that is expected.

## What this is

Reverts the StakeManager subsystem (`StakeManager.sol`, `StakeManagerExtension.sol`, `IStakeManager.sol`) to the version currently deployed at the StakeManager implementation **`0x3AD88467E40399dc6Ae10427f8B0842348d9076c`** (behind `StakeManagerProxy` `0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908`).

## TL;DR of the diff (deployed → current `main`)

The deployed version still has the **auction mechanism**, drain logic, a `slash()` no-op, and old initializers; `main` removed all of those and added the **POL-migration** path. So the diff is mostly **auction / draining / slash / old-init** (restored on this branch) plus the **POL-migration** additions (dropped here). ~ +404 / −158 lines.

## Reproduce the deployed bytecode from this branch

```
FOUNDRY_VIA_IR=false forge build --use 0.5.17 contracts/staking/stakeManager/StakeManager.sol
```

The artifact's `deployedBytecode`, metadata-stripped, equals the on-chain runtime of `0x3AD8…076c` — **24212 bytes**. This uses the repo's current `contracts/common/oz` imports; **no vendoring is needed.**

## Source commit the deployed impl was built from

The on-chain impl was compiled from commit **`5b7e40e5`** ("remove draining from stakemanager", 2024-09-24). To reproduce from *that* commit instead: check it out and build `StakeManager.sol` with `solc 0.5.17`, optimizer on / runs 200.

**Vendoring caveat:** `5b7e40e5` predates the OpenZeppelin vendoring, so it imports `openzeppelin-solidity/…`, which the current `node_modules` no longer provides — reproducing *at that commit* requires vendoring `openzeppelin-solidity@2.2.0`. **That vendoring has since happened on `main`** — OZ 2.2.0 was moved verbatim into `contracts/common/oz` — so it is **not** needed for this review branch: this branch builds against the current `common/oz` and reproduces the bytecode with a plain in-place build.
