### PR TITLE
[DO NOT MERGE] StakeManagerExtension — revert to deployed impl for bytecode review

### DIFF
--- a/contracts/staking/stakeManager/IStakeManager.sol
+++ b/contracts/staking/stakeManager/IStakeManager.sol
@@ -1,13 +1,39 @@
 pragma solidity 0.5.17;
 
 contract IStakeManager {
-    function transferFunds(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    // validator replacement
+    function startAuction(
+        uint256 validatorId,
+        uint256 amount,
+        bool acceptDelegation,
+        bytes calldata signerPubkey
+    ) external;
 
-    function transferFundsPOL(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    function confirmAuctionBid(uint256 validatorId, uint256 heimdallFee) external;
 
-    function delegationDeposit(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    function transferFunds(
+        uint256 validatorId,
+        uint256 amount,
+        address delegator
+    ) external returns (bool);
 
-    function delegationDepositPOL(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    function transferFundsPOL(
+        uint256 validatorId, 
+        uint256 amount, 
+        address delegator
+    ) external returns (bool);
+
+    function delegationDeposit(
+        uint256 validatorId,
+        uint256 amount,
+        address delegator
+    ) external returns (bool);
+
+    function delegationDepositPOL(
+        uint256 validatorId, 
+        uint256 amount, 
+        address delegator
+    ) external returns (bool);
 
     function unstake(uint256 validatorId) external;
 
@@ -36,12 +62,14 @@ contract IStakeManager {
         bytes32 voteHash,
         bytes32 stateRoot,
         address proposer,
-        uint256[3][] calldata sigs
+        uint[3][] calldata sigs
     ) external returns (uint256);
 
     function updateValidatorState(uint256 validatorId, int256 amount) public;
 
     function ownerOf(uint256 tokenId) public view returns (address);
+
+    function slash(bytes calldata slashingInfoList) external returns (uint256);
 
     function validatorStake(uint256 validatorId) public view returns (uint256);
 
@@ -51,11 +79,20 @@ contract IStakeManager {
 
     function withdrawalDelay() public view returns (uint256);
 
-    function delegatedAmount(uint256 validatorId) public view returns (uint256);
+    function delegatedAmount(uint256 validatorId) public view returns(uint256);
 
     function decreaseValidatorDelegatedAmount(uint256 validatorId, uint256 amount) public;
 
-    function withdrawDelegatorsReward(uint256 validatorId) public returns (uint256);
+    function withdrawDelegatorsReward(uint256 validatorId) public returns(uint256);
 
-    function delegatorsReward(uint256 validatorId) public view returns (uint256);
+    function delegatorsReward(uint256 validatorId) public view returns(uint256);
+
+    function dethroneAndStake(
+        address auctionUser,
+        uint256 heimdallFee,
+        uint256 validatorId,
+        uint256 auctionAmount,
+        bool acceptDelegation,
+        bytes calldata signerPubkey
+    ) external;
 }

--- a/contracts/staking/stakeManager/StakeManagerExtension.sol
+++ b/contracts/staking/stakeManager/StakeManagerExtension.sol
@@ -1,10 +1,13 @@
 pragma solidity 0.5.17;
 
+import {IERC20} from "../../common/oz/token/ERC20/IERC20.sol";
 import {SafeMath} from "../../common/oz/math/SafeMath.sol";
 import {Registry} from "../../common/Registry.sol";
 import {GovernanceLockable} from "../../common/mixin/GovernanceLockable.sol";
+import {IStakeManager} from "./IStakeManager.sol";
 import {StakeManagerStorage} from "./StakeManagerStorage.sol";
 import {StakeManagerStorageExtension} from "./StakeManagerStorageExtension.sol";
+import {Math} from "../../common/oz/math/Math.sol";
 import {Initializable} from "../../common/mixin/Initializable.sol";
 import {EventsHub} from "../EventsHub.sol";
 import {ValidatorShare} from "../validatorShare/ValidatorShare.sol";
@@ -14,7 +17,115 @@ contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManag
 
     constructor() public GovernanceLockable(address(0x0)) {}
 
-    function migrateValidatorsData(uint256 validatorIdFrom, uint256 validatorIdTo) external {
+    function startAuction(
+        uint256 validatorId,
+        uint256 amount,
+        bool _acceptDelegation,
+        bytes calldata _signerPubkey
+    ) external {
+        uint256 currentValidatorAmount = validators[validatorId].amount;
+
+        require(
+            validators[validatorId].deactivationEpoch == 0 && currentValidatorAmount != 0,
+            "Invalid validator for an auction"
+        );
+        uint256 senderValidatorId = signerToValidator[msg.sender];
+        // make sure that signer wasn't used already
+        require(
+            NFTContract.balanceOf(msg.sender) == 0 && // existing validators can't bid
+                senderValidatorId != INCORRECT_VALIDATOR_ID,
+            "Already used address"
+        );
+
+        uint256 _currentEpoch = currentEpoch;
+        uint256 _replacementCoolDown = replacementCoolDown;
+        // when dynasty period is updated validators are in cooldown period
+        require(_replacementCoolDown == 0 || _replacementCoolDown <= _currentEpoch, "Cooldown period");
+        // (auctionPeriod--dynasty)--(auctionPeriod--dynasty)--(auctionPeriod--dynasty)
+        // if it's auctionPeriod then will get residue smaller then auctionPeriod
+        // from (CurrentPeriod of validator )%(auctionPeriod--dynasty)
+        // make sure that its `auctionPeriod` window
+        // dynasty = 30, auctionPeriod = 7, activationEpoch = 1, currentEpoch = 39
+        // residue 1 = (39-1)% (7+30), if residue <= auctionPeriod it's `auctionPeriod`
+
+        require(
+            (_currentEpoch.sub(validators[validatorId].activationEpoch) % dynasty.add(auctionPeriod)) < auctionPeriod,
+            "Invalid auction period"
+        );
+
+        uint256 perceivedStake = currentValidatorAmount;
+        perceivedStake = perceivedStake.add(validators[validatorId].delegatedAmount);
+
+        Auction storage auction = validatorAuction[validatorId];
+        uint256 currentAuctionAmount = auction.amount;
+
+        perceivedStake = Math.max(perceivedStake, currentAuctionAmount);
+
+        require(perceivedStake < amount, "Must bid higher");
+        require(token.transferFrom(msg.sender, address(this), amount), "Transfer failed");
+
+        //replace prev auction
+        if (currentAuctionAmount != 0) {
+            require(token.transfer(auction.user, currentAuctionAmount), "Bid return failed");
+        }
+
+        // create new auction
+        auction.amount = amount;
+        auction.user = msg.sender;
+        auction.acceptDelegation = _acceptDelegation;
+        auction.signerPubkey = _signerPubkey;
+
+        logger.logStartAuction(validatorId, currentValidatorAmount, amount);
+    }
+
+    function confirmAuctionBid(
+        uint256 validatorId,
+        uint256 heimdallFee, /** for new validator */
+        IStakeManager stakeManager
+    ) external {
+        Auction storage auction = validatorAuction[validatorId];
+        address auctionUser = auction.user;
+
+        require(
+            msg.sender == auctionUser || NFTContract.tokenOfOwnerByIndex(msg.sender, 0) == validatorId,
+            "Only bidder can confirm"
+        );
+
+        uint256 _currentEpoch = currentEpoch;
+        require(
+            _currentEpoch.sub(auction.startEpoch) % auctionPeriod.add(dynasty) >= auctionPeriod,
+            "Not allowed before auctionPeriod"
+        );
+        require(auction.user != address(0x0), "Invalid auction");
+
+        uint256 validatorAmount = validators[validatorId].amount;
+        uint256 perceivedStake = validatorAmount;
+        uint256 auctionAmount = auction.amount;
+
+        perceivedStake = perceivedStake.add(validators[validatorId].delegatedAmount);
+
+        // validator is last auctioner
+        if (perceivedStake >= auctionAmount && validators[validatorId].deactivationEpoch == 0) {
+            require(token.transfer(auctionUser, auctionAmount), "Bid return failed");
+            //cleanup auction data
+            auction.startEpoch = _currentEpoch;
+            logger.logConfirmAuction(validatorId, validatorId, validatorAmount);
+        } else {
+            stakeManager.dethroneAndStake(
+                auctionUser, 
+                heimdallFee,
+                validatorId,
+                auctionAmount,
+                auction.acceptDelegation,
+                auction.signerPubkey
+            );
+        }
+        uint256 startEpoch = auction.startEpoch;
+        delete validatorAuction[validatorId];
+        validatorAuction[validatorId].startEpoch = startEpoch;
+    }
+
+    function migrateValidatorsData(uint256 validatorIdFrom, uint256 validatorIdTo) external {       
         for (uint256 i = validatorIdFrom; i < validatorIdTo; ++i) {
             ValidatorShare contractAddress = ValidatorShare(validators[i].contractAddress);
             if (contractAddress != ValidatorShare(0)) {
@@ -42,9 +153,7 @@ contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManag
         maxRewardedCheckpoints = _maxRewardedCheckpoints;
         checkpointRewardDelta = _checkpointRewardDelta;
 
-        _getOrCacheEventsHub().logRewardParams(
-            _rewardDecreasePerCheckpoint, _maxRewardedCheckpoints, _checkpointRewardDelta
-        );
+        _getOrCacheEventsHub().logRewardParams(_rewardDecreasePerCheckpoint, _maxRewardedCheckpoints, _checkpointRewardDelta);
     }
 
     function updateCommissionRate(uint256 validatorId, uint256 newCommissionRate) external {
@@ -52,20 +161,17 @@ contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManag
         uint256 _lastCommissionUpdate = validators[validatorId].lastCommissionUpdate;
 
         require( // withdrawalDelay == dynasty
-            (_lastCommissionUpdate.add(WITHDRAWAL_DELAY) <= _epoch) || _lastCommissionUpdate == 0, // For initial
-                // setting of commission rate
+            (_lastCommissionUpdate.add(WITHDRAWAL_DELAY) <= _epoch) || _lastCommissionUpdate == 0, // For initial setting of commission rate
             "Cooldown"
         );
 
         require(newCommissionRate <= MAX_COMMISION_RATE, "Incorrect value");
-        _getOrCacheEventsHub().logUpdateCommissionRate(
-            validatorId, newCommissionRate, validators[validatorId].commissionRate
-        );
+        _getOrCacheEventsHub().logUpdateCommissionRate(validatorId, newCommissionRate, validators[validatorId].commissionRate);
         validators[validatorId].commissionRate = newCommissionRate;
         validators[validatorId].lastCommissionUpdate = _epoch;
     }
 
-    function _getOrCacheEventsHub() private returns (EventsHub) {
+    function _getOrCacheEventsHub() private returns(EventsHub) {
         EventsHub _eventsHub = EventsHub(eventsHub);
         if (_eventsHub == EventsHub(0x0)) {
             _eventsHub = EventsHub(Registry(registry).contractMap(keccak256("eventsHub")));

--- a/contracts/staking/stakeManager/StakeManagerStorageExtension.sol
+++ b/contracts/staking/stakeManager/StakeManagerStorageExtension.sol
@@ -1,8 +1,5 @@
 pragma solidity 0.5.17;
 
-import {IPolygonMigration} from "../../common/misc/IPolygonMigration.sol";
-import {IERC20} from "../../common/oz/token/ERC20/IERC20.sol";
-
 contract StakeManagerStorageExtension {
     address public eventsHub;
     uint256 public rewardPerStake;
@@ -17,7 +14,4 @@ contract StakeManagerStorageExtension {
     uint256 public maxRewardedCheckpoints;
     // increase / decrease value for faster or slower checkpoints, 0 - 100%
     uint256 public checkpointRewardDelta;
-
-    IERC20 public tokenMatic;
-    IPolygonMigration public migration;
 }


### PR DESCRIPTION
> ⚠️ **DRAFT — DO NOT MERGE.** Review-only branch. On this branch `StakeManager.sol` intentionally **won't compile** (the pre-POL storage layout is restored), so **build only the extension**. **CI will be red** — expected.

## What this is

Reverts the StakeManagerExtension subsystem (`StakeManagerExtension.sol`, `IStakeManager.sol`, `StakeManagerStorageExtension.sol`) to the version deployed at **`0xef49Ea6996073752b6840CDA34773FFA78F78166`** (the `extensionCode` the StakeManager delegates to). The extension is much older (pre-POL) than the StakeManager, so it needs the **pre-POL** storage layout — which is why it's a separate branch from the StakeManager revert: the two deployments straddle the POL storage addition and can't share `StakeManagerStorageExtension.sol`.

## TL;DR of the diff (deployed → current `main`)

Mostly the **auction / validator-migration / checkpoint-reward** functions that were later removed, plus the **pre-POL storage** (the two POL vars `tokenMatic`/`migration` removed from `StakeManagerStorageExtension` to restore the deployed layout). ~ +161 / −24 lines.

## Reproduce the deployed bytecode from this branch

```
FOUNDRY_VIA_IR=false forge build --use 0.5.17 contracts/staking/stakeManager/StakeManagerExtension.sol
```

Metadata-stripped `deployedBytecode` equals the on-chain runtime of `0xef49…8166` — **7653 bytes**. Current `common/oz` imports; **no vendoring is needed.**

## Source commit the deployed impl was built from

Compiled from commit **`a1e3e275`** ("revert: remove migrated flag", 2021-02-25) — the truffle era. To reproduce from that commit: check it out and build `StakeManagerExtension.sol` with `solc 0.5.17`, optimizer on / runs 200, **evm-version `constantinople`** (truffle's config).

**Vendoring caveat (same as the StakeManager branch):** `a1e3e275` imports `openzeppelin-solidity/…`, so reproducing *at that commit* needs `openzeppelin-solidity@2.2.0` vendored. **That vendoring has since landed on `main`** (as `contracts/common/oz`), so it is **not** needed for this review branch — a plain in-place build against the current `common/oz` reproduces the bytecode.
