### PR TITLE
Make main reproduce the deployed on-chain bytecode

### DIFF
--- a/.github/workflows/verify-pinning.yml
+++ b/.github/workflows/verify-pinning.yml
@@ -1,0 +1,77 @@
+name: Verify on-chain pinning
+
+# Deliberately main-only.
+#
+# `main` mirrors what is deployed; `dev` holds what we intend to deploy NEXT and is therefore
+# EXPECTED to diverge from the chain.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # No schedule, deliberately. Bytecode at a fixed address never changes, so re-fetching the same
+  # addresses on a timer proves nothing about the bytecode. The verifier's `liveness` check DOES
+  # detect the system being re-pointed at a different address, which can happen with no commit at
+  # all — so a periodic run would catch something here. Left off by choice; add a `schedule:` if you
+  # want proxy upgrades surfaced without waiting for the next PR.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-pinning-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-pinning:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.OS }}-npm-cache-${{ hashFiles('./package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-npm-cache-
+
+      # Needed for tools/process-templates.cjs (commander, nunjucks, glob), which the verifier
+      # calls to render ChainIdMixin per contract. jq and python3 are preinstalled on the runner.
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      # Builds every inventory entry with its recorded solc and bor-chain-id and compares the
+      # metadata-stripped runtime against eth_getCode. Exits non-zero on any real mismatch.
+      #
+      # ~35 eth_getCode calls against the keyless Tenderly gateways in foundry.toml. Caching the
+      # fetched code under verify-onchain/onchain/ would be safe — bytecode at a fixed address is
+      # immutable — but is not worth the complexity at this size.
+      - name: Verify pinned contracts reproduce on-chain bytecode
+        run: script/pinning/verify-bytecode.sh
+
+      # verify-onchain/ is gitignored, so on failure these are the only way to see WHERE the
+      # bytecode diverged rather than just that it did.
+      - name: Upload diff artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pinning-diffs
+          path: |
+            verify-onchain/results.json
+            verify-onchain/diffs/
+            verify-onchain/build-failures.log
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,12 @@ coverage/
 coverage.json
 
 cache
+
+# script/pinning/verify-bytecode.sh work dir (cached on-chain code, per-solc builds, diffs)
+verify-onchain
+__pycache__/
+
+regression-replay
+.test-port
+
+.claude

--- a/README.md
+++ b/README.md
@@ -92,6 +92,66 @@ npm run coverage
 
 The report is written to `coverage/` (gitignored). Open `coverage/index.html` to browse.
 
+## Verifying on-chain bytecode
+
+`main` is meant to reproduce the exact runtime bytecode of what is deployed. This checks that it
+still does: for every contract in `script/pinning/pinned-contracts.json` it builds from source and
+compares against `eth_getCode` at the deployed address.
+
+Requires `forge`, `cast`, `jq` and `python3`.
+
+```
+script/pinning/verify-bytecode.sh
+```
+
+Pass chain ids to narrow the run (`1` = Ethereum, `137` = Polygon PoS); the default is every chain:
+
+```
+script/pinning/verify-bytecode.sh 1
+```
+
+RPC endpoints come from the `rpc` map in the inventory, which points at the `foundry.toml` aliases —
+override with `MAINNET_RPC_URL` / `POLYGON_POS_RPC_URL` if you need better rate limits.
+
+### Reading the output
+
+It prints a table and exits non-zero if anything is a real mismatch.
+
+| Status | Meaning |
+|---|---|
+| `MATCH_NO_META` | **The expected pass.** Identical once the trailing metadata is stripped. |
+| `MATCH` | Byte-identical including metadata. Rare — see below. |
+| `MISMATCH` | Logic differs. Both stripped blobs are dumped to `verify-onchain/diffs/`. |
+| `NO_CODE` / `MISSING_ARTIFACT` | Nothing deployed at the address / the local build produced no artifact. |
+
+`MATCH_NO_META` rather than `MATCH` is the normal result: solc appends a CBOR trailer that hashes the
+source paths and compiler settings, so it is never reproducible and is stripped from both sides before
+comparing. Everything before it must match byte for byte.
+
+Artifacts, cached on-chain code, `results.json` and any diffs land in `verify-onchain/` (gitignored).
+
+### The inventory
+
+`script/pinning/pinned-contracts.json` is the source of truth; read its `_comment` for the full
+schema. The fields that matter:
+
+- `solc` — the compiler the contract was **deployed** with. Contracts are built one group at a time
+  with `--use`, because a single auto-detected version does not reproduce all of them.
+- `borChainId` — contracts embedding `ChainIdMixin` bake the chain id into their bytecode, and the
+  live contracts do **not** all use the same value (some are `137`, some `15001`). The script
+  re-renders the template per group, so no single build could cover them all.
+- `upgradeable` — an implementation behind a proxy or Registry lookup. Not a strict pin, but verified
+  informationally: the repo should still reproduce whatever is live today.
+- `exclude` — documented but skipped, for contracts that legitimately cannot reproduce from current
+  source. Do not add this to silence a regression.
+
+Because those build inputs are load-bearing, a plain `forge build` will *silently* mismatch several
+contracts. Any CI guard has to drive the build the same way this script does.
+
+The script temporarily relaxes `IStakeManager`'s pragma so the 0.5.11-era proxies compile, and
+re-renders `ChainIdMixin`; both are restored on exit, including the `test-bor-docker/genesis.json`
+that template processing rewrites as a side effect.
+
 ## Contact
 
 For more discussions, please head to the [R&D Discord](https://discord.gg/0xPolygonRnD)

--- a/README.md
+++ b/README.md
@@ -123,7 +123,11 @@ It prints a table and exits non-zero if anything is a real mismatch.
 | `MATCH` | Byte-identical including metadata. Rare — see below. |
 | `MISMATCH` | Logic differs. Both stripped blobs are dumped to `verify-onchain/diffs/`. |
 | `STALE_POINTER` | The live system no longer points at the address we pin — see below. |
+| `POINTER_UNRESOLVED` | The liveness call could not be read at all. Usually a flaky RPC, **not** drift — retry before investigating. |
 | `NO_CODE` / `MISSING_ARTIFACT` | Nothing deployed at the address / the local build produced no artifact. |
+
+Only `MATCH` and `MATCH_NO_META` pass; every other status exits non-zero. Verifying zero contracts
+(a typo'd chain argument, say) is also an error rather than a clean run.
 
 `MATCH_NO_META` rather than `MATCH` is the normal result: solc appends a CBOR trailer that hashes the
 source paths and compiler settings, so it is never reproducible and is stripped from both sides before

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ It prints a table and exits non-zero if anything is a real mismatch.
 | `MATCH_NO_META` | **The expected pass.** Identical once the trailing metadata is stripped. |
 | `MATCH` | Byte-identical including metadata. Rare — see below. |
 | `MISMATCH` | Logic differs. Both stripped blobs are dumped to `verify-onchain/diffs/`. |
+| `STALE_POINTER` | The live system no longer points at the address we pin — see below. |
 | `NO_CODE` / `MISSING_ARTIFACT` | Nothing deployed at the address / the local build produced no artifact. |
 
 `MATCH_NO_META` rather than `MATCH` is the normal result: solc appends a CBOR trailer that hashes the
@@ -144,6 +145,14 @@ schema. The fields that matter:
   informationally: the repo should still reproduce whatever is live today.
 - `exclude` — documented but skipped, for contracts that legitimately cannot reproduce from current
   source. Do not add this to silence a regression.
+- `liveness` — a `target` + `sig` call whose returned address must still equal the entry's own
+  `address`. Bytecode at a fixed address is immutable, so comparing bytecode can never detect the
+  system being re-pointed at a **different** address: after a proxy upgrade or a Registry
+  re-registration the old address keeps its code and the check would stay green while `main` no
+  longer mirrors what is live. That has already happened once — `Registry.erc20Predicate()` moved
+  from `0x626fb210…` to `0x4EeA1780…`. Add it to anything reached through a pointer; a drift is
+  reported as `STALE_POINTER` naming the address now returned, and the fix is to repoint the
+  inventory and re-run to see whether the new implementation still reproduces.
 
 Because those build inputs are load-bearing, a plain `forge build` will *silently* mismatch several
 contracts. Any CI guard has to drive the build the same way this script does.

--- a/contracts/child/misc/EIP712.sol
+++ b/contracts/child/misc/EIP712.sol
@@ -7,8 +7,14 @@ contract LibEIP712Domain is ChainIdMixin {
         "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)";
     bytes32 public constant EIP712_DOMAIN_SCHEMA_HASH = keccak256(abi.encodePacked(EIP712_DOMAIN_SCHEMA));
 
-    string internal constant EIP712_DOMAIN_NAME = "Polygon Ecosystem Token";
-    string internal constant EIP712_DOMAIN_VERSION = "2";
+    // These are the values the deployed proxified child-token implementations were built with
+    // (0x53a0BB… / 0xa45b96… ChildERC20Proxified, 0xd2Cb63… ChildERC721Proxified). The POL rename
+    // moved them to "Polygon Ecosystem Token"/"2" (c0a3fd7d, 62fc8652, 39e006fa) but that has never
+    // been deployed. Changing them changes EIP712_DOMAIN_HASH, i.e. the EIP-712 domain separator, so
+    // any redeploy of those impls with new values invalidates outstanding transferWithSig signatures.
+    // Keep test/helpers/marketplaceUtils.js.template's signing domain in sync.
+    string internal constant EIP712_DOMAIN_NAME = "Matic Network";
+    string internal constant EIP712_DOMAIN_VERSION = "1";
     uint256 internal constant EIP712_DOMAIN_CHAINID = CHAINID;
 
     bytes32 public EIP712_DOMAIN_HASH;

--- a/contracts/staking/stakeManager/IStakeManager.sol
+++ b/contracts/staking/stakeManager/IStakeManager.sol
@@ -1,13 +1,39 @@
 pragma solidity 0.5.17;
 
 contract IStakeManager {
-    function transferFunds(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    // validator replacement
+    function startAuction(
+        uint256 validatorId,
+        uint256 amount,
+        bool acceptDelegation,
+        bytes calldata signerPubkey
+    ) external;
 
-    function transferFundsPOL(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    function confirmAuctionBid(uint256 validatorId, uint256 heimdallFee) external;
 
-    function delegationDeposit(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    function transferFunds(
+        uint256 validatorId,
+        uint256 amount,
+        address delegator
+    ) external returns (bool);
 
-    function delegationDepositPOL(uint256 validatorId, uint256 amount, address delegator) external returns (bool);
+    function transferFundsPOL(
+        uint256 validatorId, 
+        uint256 amount, 
+        address delegator
+    ) external returns (bool);
+
+    function delegationDeposit(
+        uint256 validatorId,
+        uint256 amount,
+        address delegator
+    ) external returns (bool);
+
+    function delegationDepositPOL(
+        uint256 validatorId, 
+        uint256 amount, 
+        address delegator
+    ) external returns (bool);
 
     function unstake(uint256 validatorId) external;
 
@@ -36,12 +62,14 @@ contract IStakeManager {
         bytes32 voteHash,
         bytes32 stateRoot,
         address proposer,
-        uint256[3][] calldata sigs
+        uint[3][] calldata sigs
     ) external returns (uint256);
 
     function updateValidatorState(uint256 validatorId, int256 amount) public;
 
     function ownerOf(uint256 tokenId) public view returns (address);
+
+    function slash(bytes calldata slashingInfoList) external returns (uint256);
 
     function validatorStake(uint256 validatorId) public view returns (uint256);
 
@@ -51,11 +79,20 @@ contract IStakeManager {
 
     function withdrawalDelay() public view returns (uint256);
 
-    function delegatedAmount(uint256 validatorId) public view returns (uint256);
+    function delegatedAmount(uint256 validatorId) public view returns(uint256);
 
     function decreaseValidatorDelegatedAmount(uint256 validatorId, uint256 amount) public;
 
-    function withdrawDelegatorsReward(uint256 validatorId) public returns (uint256);
+    function withdrawDelegatorsReward(uint256 validatorId) public returns(uint256);
 
-    function delegatorsReward(uint256 validatorId) public view returns (uint256);
+    function delegatorsReward(uint256 validatorId) public view returns(uint256);
+
+    function dethroneAndStake(
+        address auctionUser,
+        uint256 heimdallFee,
+        uint256 validatorId,
+        uint256 auctionAmount,
+        bool acceptDelegation,
+        bytes calldata signerPubkey
+    ) external;
 }

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -8,8 +8,10 @@ import {ECVerify} from "../../common/lib/ECVerify.sol";
 import {Merkle} from "../../common/lib/Merkle.sol";
 import {GovernanceLockable} from "../../common/mixin/GovernanceLockable.sol";
 import {DelegateProxyForwarder} from "../../common/misc/DelegateProxyForwarder.sol";
+import {Registry} from "../../common/Registry.sol";
 import {IStakeManager} from "./IStakeManager.sol";
 import {IValidatorShare} from "../validatorShare/IValidatorShare.sol";
+import {ValidatorShare} from "../validatorShare/ValidatorShare.sol";
 import {StakingInfo} from "../StakingInfo.sol";
 import {StakingNFT} from "./StakingNFT.sol";
 import {ValidatorShareFactory} from "../validatorShare/ValidatorShareFactory.sol";
@@ -69,42 +71,63 @@ contract StakeManager is
     function initialize(
         address _registry,
         address _rootchain,
-        address _tokenLegacy,
+        address _token,
         address _NFTContract,
         address _stakingLogger,
         address _validatorShareFactory,
         address _governance,
         address _owner,
-        address _extensionCode,
-        address _token,
-        address _migration
+        address _extensionCode
     ) external initializer {
-        require(isContract(_extensionCode), "extension impl incorrect");
+        require(isContract(_extensionCode), "auction impl incorrect");
         extensionCode = _extensionCode;
         governance = IGovernance(_governance);
         registry = _registry;
         rootChain = _rootchain;
         token = IERC20(_token);
-        tokenMatic = IERC20(_tokenLegacy);
-        migration = IPolygonMigration(_migration);
         NFTContract = StakingNFT(_NFTContract);
         logger = StakingInfo(_stakingLogger);
         validatorShareFactory = ValidatorShareFactory(_validatorShareFactory);
         _transferOwnership(_owner);
 
-        WITHDRAWAL_DELAY = (2 ** 13); // unit: epoch
+        WITHDRAWAL_DELAY = (2**13); // unit: epoch
         currentEpoch = 1;
         dynasty = 886; // unit: epoch 50 days
-        CHECKPOINT_REWARD = 20_188 * (10 ** 18); // update via governance
-        minDeposit = (10 ** 18); // in ERC20 token
-        minHeimdallFee = (10 ** 18); // in ERC20 token
+        CHECKPOINT_REWARD = 20188 * (10**18); // update via governance
+        minDeposit = (10**18); // in ERC20 token
+        minHeimdallFee = (10**18); // in ERC20 token
         checkPointBlockInterval = 1024;
         signerUpdateLimit = 100;
 
         validatorThreshold = 7; //128
         NFTCounter = 1;
+        auctionPeriod = (2**13) / 4; // 1 week in epochs
         proposerBonus = 10; // 10 % of total rewards
         delegationEnabled = true;
+    }
+
+    function reinitialize(
+        address _NFTContract,
+        address _stakingLogger,
+        address _validatorShareFactory,
+        address _extensionCode
+    ) external onlyGovernance {
+        require(isContract(_extensionCode));
+        eventsHub = address(0x0);
+        extensionCode = _extensionCode;
+        NFTContract = StakingNFT(_NFTContract);
+        logger = StakingInfo(_stakingLogger);
+        validatorShareFactory = ValidatorShareFactory(_validatorShareFactory);
+    }
+
+    function initializePOL(
+        address _tokenNew,
+        address _migration
+    ) external onlyGovernance {
+        tokenMatic = IERC20(token);
+        token = IERC20(_tokenNew);
+        migration = IPolygonMigration(_migration);
+        _convertMaticToPOL(tokenMatic.balanceOf(address(this)));
     }
 
     function isOwner() public view returns (bool) {
@@ -117,14 +140,15 @@ contract StakeManager is
     }
 
     /**
-     * Public View Methods
+        Public View Methods
      */
+
     function getRegistry() public view returns (address) {
         return registry;
     }
 
     /**
-     * @dev Owner of validator slot NFT
+        @dev Owner of validator slot NFT
      */
     function ownerOf(uint256 tokenId) public view returns (address) {
         return NFTContract.ownerOf(tokenId);
@@ -161,7 +185,7 @@ contract StakeManager is
     function validatorReward(uint256 validatorId) public view returns (uint256) {
         uint256 _validatorReward;
         if (validators[validatorId].deactivationEpoch == 0) {
-            (_validatorReward,) = _evaluateValidatorAndDelegationReward(validatorId);
+            (_validatorReward, ) = _evaluateValidatorAndDelegationReward(validatorId);
         }
         return validators[validatorId].reward.add(_validatorReward).sub(INITIALIZED_AMOUNT);
     }
@@ -179,17 +203,19 @@ contract StakeManager is
     }
 
     function isValidator(uint256 validatorId) public view returns (bool) {
-        return _isValidator(
-            validators[validatorId].status,
-            validators[validatorId].amount,
-            validators[validatorId].deactivationEpoch,
-            currentEpoch
-        );
+        return
+            _isValidator(
+                validators[validatorId].status,
+                validators[validatorId].amount,
+                validators[validatorId].deactivationEpoch,
+                currentEpoch
+            );
     }
 
     /**
-     * Governance Methods
+        Governance Methods
      */
+
     function setDelegationEnabled(bool enabled) public onlyGovernance {
         delegationEnabled = enabled;
     }
@@ -205,6 +231,11 @@ contract StakeManager is
 
     function setCurrentEpoch(uint256 _currentEpoch) external onlyGovernance {
         currentEpoch = _currentEpoch;
+    }
+
+    function setStakingToken(address _token) public onlyGovernance {
+        require(_token != address(0x0));
+        token = IERC20(_token);
     }
 
     /**
@@ -249,7 +280,9 @@ contract StakeManager is
         delegatedFwd(
             extensionCode,
             abi.encodeWithSelector(
-                StakeManagerExtension(extensionCode).migrateValidatorsData.selector, validatorIdFrom, validatorIdTo
+                StakeManagerExtension(extensionCode).migrateValidatorsData.selector,
+                validatorIdFrom,
+                validatorIdTo
             )
         );
     }
@@ -259,7 +292,7 @@ contract StakeManager is
     }
 
     /**
-     * @dev Users must exit before this update or all funds may get lost
+        @dev Users must exit before this update or all funds may get lost
      */
     function updateValidatorContractAddress(uint256 validatorId, address newContractAddress) public onlyGovernance {
         require(IValidatorShare(newContractAddress).owner() == address(this));
@@ -271,6 +304,13 @@ contract StakeManager is
         logger.logDynastyValueChange(newDynasty, dynasty);
         dynasty = newDynasty;
         WITHDRAWAL_DELAY = newDynasty;
+        auctionPeriod = newDynasty.div(4);
+        replacementCoolDown = currentEpoch.add(auctionPeriod);
+    }
+
+    // Housekeeping function. @todo remove later
+    function stopAuctions(uint256 forNCheckpoints) public onlyGovernance {
+        replacementCoolDown = currentEpoch.add(forNCheckpoints);
     }
 
     function updateProposerBonus(uint256 newProposerBonus) public onlyGovernance {
@@ -289,17 +329,14 @@ contract StakeManager is
     }
 
     /**
-     * Public Methods
+        Public Methods
      */
     function topUpForFee(address user, uint256 heimdallFee) public onlyWhenUnlocked {
         _transferAndTopUp(user, msg.sender, heimdallFee, 0, true);
     }
 
     function claimFee(uint256 accumFeeAmount, uint256 index, bytes memory proof) public {
-        require(
-            keccak256(abi.encode(msg.sender, accumFeeAmount)).checkMembership(index, accountStateRoot, proof),
-            "Wrong acc proof"
-        );
+        require(keccak256(abi.encode(msg.sender, accumFeeAmount)).checkMembership(index, accountStateRoot, proof), "Wrong acc proof");
         uint256 withdrawAmount = accumFeeAmount.sub(userFeeExit[msg.sender]);
         totalHeimdallFee = totalHeimdallFee.sub(withdrawAmount);
         logger.logClaimFee(msg.sender, withdrawAmount);
@@ -314,6 +351,56 @@ contract StakeManager is
         return validators[NFTContract.tokenOfOwnerByIndex(user, 0)].amount;
     }
 
+    function startAuction(
+        uint256 validatorId,
+        uint256 amount,
+        bool _acceptDelegation,
+        bytes calldata _signerPubkey
+    ) external onlyWhenUnlocked {
+        delegatedFwd(
+            extensionCode,
+            abi.encodeWithSelector(
+                StakeManagerExtension(extensionCode).startAuction.selector,
+                validatorId,
+                amount,
+                _acceptDelegation,
+                _signerPubkey
+            )
+        );
+    }
+
+    function confirmAuctionBid(
+        uint256 validatorId,
+        uint256 heimdallFee /** for new validator */
+    ) external onlyWhenUnlocked {
+        delegatedFwd(
+            extensionCode,
+            abi.encodeWithSelector(
+                StakeManagerExtension(extensionCode).confirmAuctionBid.selector,
+                validatorId,
+                heimdallFee,
+                address(this)
+            )
+        );
+    }
+
+    function dethroneAndStake(
+        address auctionUser,
+        uint256 heimdallFee,
+        uint256 validatorId,
+        uint256 auctionAmount,
+        bool acceptDelegation,
+        bytes calldata signerPubkey
+    ) external {
+        require(msg.sender == address(this), "not allowed");
+        // dethrone
+        _transferAndTopUp(auctionUser, auctionUser, heimdallFee, 0, true);
+        _unstake(validatorId, currentEpoch, true);
+
+        uint256 newValidatorId = _stakeFor(auctionUser, auctionAmount, acceptDelegation, signerPubkey);
+        logger.logConfirmAuction(newValidatorId, validatorId, auctionAmount);
+    }
+
     function unstake(uint256 validatorId) external onlyStaker(validatorId) {
         _unstakeValidator(validatorId, false);
     }
@@ -323,10 +410,13 @@ contract StakeManager is
     }
 
     function _unstakeValidator(uint256 validatorId, bool pol) internal {
+        require(validatorAuction[validatorId].amount == 0);
+
         Status status = validators[validatorId].status;
         require(
-            validators[validatorId].activationEpoch > 0 && validators[validatorId].deactivationEpoch == 0
-                && (status == Status.Active || status == Status.Locked)
+            validators[validatorId].activationEpoch > 0 &&
+                validators[validatorId].deactivationEpoch == 0 &&
+                (status == Status.Active || status == Status.Locked)
         );
 
         uint256 exitEpoch = currentEpoch.add(1); // notice period
@@ -342,25 +432,17 @@ contract StakeManager is
     }
 
     function _transferFunds(uint256 validatorId, uint256 amount, address delegator, bool pol) internal returns (bool) {
-        require(validators[validatorId].contractAddress == msg.sender, "not allowed");
+        require(validators[validatorId].contractAddress == msg.sender || Registry(registry).getSlashingManagerAddress() == msg.sender, "not allowed");
         if (!pol) _convertPOLToMatic(amount);
         IERC20 token_ = _getToken(pol);
         return token_.transfer(delegator, amount);
     }
 
-    function delegationDeposit(
-        uint256 validatorId,
-        uint256 amount,
-        address delegator
-    ) external onlyDelegation(validatorId) returns (bool) {
+    function delegationDeposit(uint256 validatorId, uint256 amount, address delegator) external onlyDelegation(validatorId) returns (bool) {
         return _delegationDeposit(amount, delegator, false);
     }
 
-    function delegationDepositPOL(
-        uint256 validatorId,
-        uint256 amount,
-        address delegator
-    ) external onlyDelegation(validatorId) returns (bool) {
+    function delegationDepositPOL(uint256 validatorId, uint256 amount, address delegator) external onlyDelegation(validatorId) returns (bool) {
         return _delegationDeposit(amount, delegator, true);
     }
 
@@ -371,34 +453,15 @@ contract StakeManager is
         return result;
     }
 
-    function stakeFor(
-        address user,
-        uint256 amount,
-        uint256 heimdallFee,
-        bool acceptDelegation,
-        bytes memory signerPubkey
-    ) public onlyWhenUnlocked {
+    function stakeFor(address user, uint256 amount, uint256 heimdallFee, bool acceptDelegation, bytes memory signerPubkey) public onlyWhenUnlocked {
         _stakeFor(user, amount, heimdallFee, acceptDelegation, signerPubkey, false);
     }
 
-    function stakeForPOL(
-        address user,
-        uint256 amount,
-        uint256 heimdallFee,
-        bool acceptDelegation,
-        bytes memory signerPubkey
-    ) public onlyWhenUnlocked {
+    function stakeForPOL(address user, uint256 amount, uint256 heimdallFee, bool acceptDelegation, bytes memory signerPubkey) public onlyWhenUnlocked {
         _stakeFor(user, amount, heimdallFee, acceptDelegation, signerPubkey, true);
     }
 
-    function _stakeFor(
-        address user,
-        uint256 amount,
-        uint256 heimdallFee,
-        bool acceptDelegation,
-        bytes memory signerPubkey,
-        bool pol
-    ) internal {
+    function _stakeFor(address user, uint256 amount, uint256 heimdallFee, bool acceptDelegation, bytes memory signerPubkey, bool pol) internal {
         require(currentValidatorSetSize() < validatorThreshold, "no more slots");
         require(amount >= minDeposit, "not enough deposit");
         _transferAndTopUp(user, msg.sender, heimdallFee, amount, pol);
@@ -417,8 +480,9 @@ contract StakeManager is
         uint256 deactivationEpoch = validators[validatorId].deactivationEpoch;
         // can only claim stake back after WITHDRAWAL_DELAY
         require(
-            deactivationEpoch > 0 && deactivationEpoch.add(WITHDRAWAL_DELAY) <= currentEpoch
-                && validators[validatorId].status != Status.Unstaked
+            deactivationEpoch > 0 &&
+                deactivationEpoch.add(WITHDRAWAL_DELAY) <= currentEpoch &&
+                validators[validatorId].status != Status.Unstaked
         );
 
         uint256 amount = validators[validatorId].amount;
@@ -441,19 +505,11 @@ contract StakeManager is
         logger.logUnstaked(msg.sender, validatorId, amount, newTotalStaked);
     }
 
-    function restake(
-        uint256 validatorId,
-        uint256 amount,
-        bool stakeRewards
-    ) public onlyWhenUnlocked onlyStaker(validatorId) {
+    function restake(uint256 validatorId, uint256 amount, bool stakeRewards) public onlyWhenUnlocked onlyStaker(validatorId) {
         _restake(validatorId, amount, stakeRewards, false);
     }
 
-    function restakePOL(
-        uint256 validatorId,
-        uint256 amount,
-        bool stakeRewards
-    ) public onlyWhenUnlocked onlyStaker(validatorId) {
+    function restakePOL(uint256 validatorId, uint256 amount, bool stakeRewards) public onlyWhenUnlocked onlyStaker(validatorId) {
         _restake(validatorId, amount, stakeRewards, true);
     }
 
@@ -494,7 +550,11 @@ contract StakeManager is
         _liquidateRewards(validatorId, msg.sender, pol);
     }
 
-    function migrateDelegation(uint256 fromValidatorId, uint256 toValidatorId, uint256 amount) public {
+    function migrateDelegation(
+        uint256 fromValidatorId,
+        uint256 toValidatorId,
+        uint256 amount
+    ) public {
         // allow to move to any non-foundation node
         require(toValidatorId > 7, "Invalid migration");
         IValidatorShare(validators[fromValidatorId].contractAddress).migrateOut(msg.sender, amount);
@@ -509,13 +569,12 @@ contract StakeManager is
 
         uint256 deactivationEpoch = validators[validatorId].deactivationEpoch;
 
-        if (deactivationEpoch == 0) {
-            // modify timeline only if validator didn't unstake
+        if (deactivationEpoch == 0) { // modify timeline only if validator didn't unstake
             updateTimeline(amount, 0, 0);
-        } else if (deactivationEpoch > currentEpoch) {
-            // validator just unstaked, need to wait till next checkpoint
+        } else if (deactivationEpoch > currentEpoch) { // validator just unstaked, need to wait till next checkpoint
             revert("unstaking");
         }
+        
 
         if (amount >= 0) {
             increaseValidatorDelegatedAmount(validatorId, uint256(amount));
@@ -540,8 +599,8 @@ contract StakeManager is
         address currentSigner = validators[validatorId].signer;
         // update signer event
         logger.logSignerChange(validatorId, currentSigner, signer, signerPubkey);
-
-        if (validators[validatorId].deactivationEpoch == 0) {
+        
+        if (validators[validatorId].deactivationEpoch == 0) { 
             // didn't unstake, swap signer in the list
             _removeSigner(currentSigner);
             _insertSigner(signer);
@@ -618,16 +677,17 @@ contract StakeManager is
         // find the rest of validators without signature
         unsignedCtx = _fillUnsignedValidators(unsignedCtx, address(0));
 
-        return _increaseRewardAndAssertConsensus(
-            blockInterval,
-            proposer,
-            signedStakePower,
-            stateRoot,
-            unsignedCtx.unsignedValidators,
-            unsignedCtx.unsignedValidatorIndex,
-            unstakeCtx.deactivatedValidators,
-            unstakeCtx.validatorIndex
-        );
+        return
+            _increaseRewardAndAssertConsensus(
+                blockInterval,
+                proposer,
+                signedStakePower,
+                stateRoot,
+                unsignedCtx.unsignedValidators,
+                unsignedCtx.unsignedValidatorIndex,
+                unstakeCtx.deactivatedValidators,
+                unstakeCtx.validatorIndex
+            );
     }
 
     function updateCommissionRate(uint256 validatorId, uint256 newCommissionRate) external onlyStaker(validatorId) {
@@ -636,7 +696,9 @@ contract StakeManager is
         delegatedFwd(
             extensionCode,
             abi.encodeWithSelector(
-                StakeManagerExtension(extensionCode).updateCommissionRate.selector, validatorId, newCommissionRate
+                StakeManagerExtension(extensionCode).updateCommissionRate.selector,
+                validatorId,
+                newCommissionRate
             )
         );
     }
@@ -649,7 +711,39 @@ contract StakeManager is
         return totalReward;
     }
 
-    function updateTimeline(int256 amount, int256 stakerCount, uint256 targetEpoch) internal {
+    function slash(bytes calldata _slashingInfoList) external returns (uint256) {
+        revert();
+    }
+
+    function unjail(uint256 validatorId) public onlyStaker(validatorId) {
+        require(validators[validatorId].status == Status.Locked, "Not jailed");
+        require(validators[validatorId].deactivationEpoch == 0, "Already unstaking");
+
+        uint256 _currentEpoch = currentEpoch;
+        require(validators[validatorId].jailTime <= _currentEpoch, "Incomplete jail period");
+
+        uint256 amount = validators[validatorId].amount;
+        require(amount >= minDeposit);
+
+        address delegationContract = validators[validatorId].contractAddress;
+        if (delegationContract != address(0x0)) {
+            IValidatorShare(delegationContract).unlock();
+        }
+
+        // undo timeline so that validator is normal validator
+        updateTimeline(int256(amount.add(validators[validatorId].delegatedAmount)), 1, 0);
+
+        validators[validatorId].status = Status.Active;
+
+        address signer = validators[validatorId].signer;
+        logger.logUnjailed(validatorId, signer);
+    }
+
+    function updateTimeline(
+        int256 amount,
+        int256 stakerCount,
+        uint256 targetEpoch
+    ) internal {
         if (targetEpoch == 0) {
             // update total stake and validator count
             if (amount > 0) {
@@ -688,8 +782,9 @@ contract StakeManager is
     }
 
     /**
-     * Private Methods
+        Private Methods
      */
+
     function _getAndAssertSigner(bytes memory pub) private view returns (address) {
         require(pub.length == 64, "not pub");
         address signer = address(uint160(uint256(keccak256(pub))));
@@ -706,14 +801,13 @@ contract StakeManager is
         return (amount > 0 && (deactivationEpoch == 0 || deactivationEpoch > _currentEpoch) && status == Status.Active);
     }
 
-    function _fillUnsignedValidators(
-        UnsignedValidatorsContext memory context,
-        address signer
-    ) private view returns (UnsignedValidatorsContext memory) {
-        while (context.validatorIndex < context.totalValidators && context.validators[context.validatorIndex] != signer)
-        {
-            context.unsignedValidators[context.unsignedValidatorIndex] =
-                signerToValidator[context.validators[context.validatorIndex]];
+    function _fillUnsignedValidators(UnsignedValidatorsContext memory context, address signer)
+        private
+        view
+        returns(UnsignedValidatorsContext memory)
+    {
+        while (context.validatorIndex < context.totalValidators && context.validators[context.validatorIndex] != signer) {
+            context.unsignedValidators[context.unsignedValidatorIndex] = signerToValidator[context.validators[context.validatorIndex]];
             context.unsignedValidatorIndex++;
             context.validatorIndex++;
         }
@@ -743,7 +837,7 @@ contract StakeManager is
             if (prevBlockInterval != 0) {
                 // give more reward for faster and less for slower checkpoint
                 uint256 delta = (ckpReward * checkpointRewardDelta / CHK_REWARD_PRECISION);
-
+                
                 if (prevBlockInterval > fullIntervals) {
                     // checkpoint is faster
                     ckpReward += delta;
@@ -751,7 +845,7 @@ contract StakeManager is
                     ckpReward -= delta;
                 }
             }
-
+            
             prevBlockInterval = fullIntervals;
         }
 
@@ -762,16 +856,11 @@ contract StakeManager is
             uint256 _rewardDecreasePerCheckpoint = rewardDecreasePerCheckpoint;
 
             // calculate reward for full intervals
-            reward = ckpReward.mul(fullIntervals).sub(
-                ckpReward.mul(((fullIntervals - 1) * fullIntervals / 2).mul(_rewardDecreasePerCheckpoint)).div(
-                    CHK_REWARD_PRECISION
-                )
-            );
+            reward = ckpReward.mul(fullIntervals).sub(ckpReward.mul(((fullIntervals - 1) * fullIntervals / 2).mul(_rewardDecreasePerCheckpoint)).div(CHK_REWARD_PRECISION));
             // adjust block interval, in case last interval is not full
             blockInterval = blockInterval.sub(fullIntervals.mul(targetBlockInterval));
             // adjust checkpoint reward by the amount it suppose to decrease
-            ckpReward =
-                ckpReward.sub(ckpReward.mul(fullIntervals).mul(_rewardDecreasePerCheckpoint).div(CHK_REWARD_PRECISION));
+            ckpReward = ckpReward.sub(ckpReward.mul(fullIntervals).mul(_rewardDecreasePerCheckpoint).div(CHK_REWARD_PRECISION));
         }
 
         // give proportionally less for the rest
@@ -807,15 +896,13 @@ contract StakeManager is
         uint256 newRewardPerStake =
             rewardPerStake.add(reward.sub(_proposerBonus).mul(REWARD_PRECISION).div(signedStakePower));
 
-        // evaluate rewards for validator who did't sign and set latest reward per stake to new value to avoid them from
-        // getting new rewards.
+        // evaluate rewards for validator who did't sign and set latest reward per stake to new value to avoid them from getting new rewards.
         _updateValidatorsRewards(unsignedValidators, totalUnsignedValidators, newRewardPerStake);
 
         // distribute rewards between signed validators
         rewardPerStake = newRewardPerStake;
 
-        // evaluate rewards for unstaked validators to ensure they get the reward for signing during their
-        // deactivationEpoch
+        // evaluate rewards for unstaked validators to ensure they get the reward for signing during their deactivationEpoch
         _updateValidatorsRewards(deactivatedValidators, totalDeactivatedValidators, newRewardPerStake);
 
         _finalizeCommit();
@@ -848,19 +935,29 @@ contract StakeManager is
         // attempt to save gas in case if rewards were updated previously
         if (initialRewardPerStake < currentRewardPerStake) {
             uint256 validatorsStake = validators[validatorId].amount;
-            uint256 valDelegatedAmount = validators[validatorId].delegatedAmount;
-            if (valDelegatedAmount > 0) {
-                uint256 combinedStakePower = validatorsStake.add(valDelegatedAmount);
+            uint256 delegatedAmount = validators[validatorId].delegatedAmount;
+            if (delegatedAmount > 0) {
+                uint256 combinedStakePower = validatorsStake.add(delegatedAmount);
                 _increaseValidatorRewardWithDelegation(
                     validatorId,
                     validatorsStake,
-                    valDelegatedAmount,
-                    _getEligibleValidatorReward(combinedStakePower, currentRewardPerStake, initialRewardPerStake)
+                    delegatedAmount,
+                    _getEligibleValidatorReward(
+                        validatorId,
+                        combinedStakePower,
+                        currentRewardPerStake,
+                        initialRewardPerStake
+                    )
                 );
             } else {
                 _increaseValidatorReward(
                     validatorId,
-                    _getEligibleValidatorReward(validatorsStake, currentRewardPerStake, initialRewardPerStake)
+                    _getEligibleValidatorReward(
+                        validatorId,
+                        validatorsStake,
+                        currentRewardPerStake,
+                        initialRewardPerStake
+                    )
                 );
             }
         }
@@ -875,6 +972,7 @@ contract StakeManager is
     }
 
     function _getEligibleValidatorReward(
+        uint256 validatorId,
         uint256 validatorStakePower,
         uint256 currentRewardPerStake,
         uint256 initialRewardPerStake
@@ -892,19 +990,19 @@ contract StakeManager is
     function _increaseValidatorRewardWithDelegation(
         uint256 validatorId,
         uint256 validatorsStake,
-        uint256 valDelegatedAmount,
+        uint256 delegatedAmount,
         uint256 reward
     ) private {
-        uint256 combinedStakePower = valDelegatedAmount.add(validatorsStake);
-        (uint256 valReward, uint256 delReward) =
+        uint256 combinedStakePower = delegatedAmount.add(validatorsStake);
+        (uint256 validatorReward, uint256 delegatorsReward) =
             _getValidatorAndDelegationReward(validatorId, validatorsStake, reward, combinedStakePower);
 
-        if (delReward > 0) {
-            validators[validatorId].delegatorsReward = validators[validatorId].delegatorsReward.add(delReward);
+        if (delegatorsReward > 0) {
+            validators[validatorId].delegatorsReward = validators[validatorId].delegatorsReward.add(delegatorsReward);
         }
 
-        if (valReward > 0) {
-            validators[validatorId].reward = validators[validatorId].reward.add(valReward);
+        if (validatorReward > 0) {
+            validators[validatorId].reward = validators[validatorId].reward.add(validatorReward);
         }
     }
 
@@ -918,32 +1016,35 @@ contract StakeManager is
             return (0, 0);
         }
 
-        uint256 valReward = validatorsStake.mul(reward).div(combinedStakePower);
+        uint256 validatorReward = validatorsStake.mul(reward).div(combinedStakePower);
 
         // add validator commission from delegation reward
         uint256 commissionRate = validators[validatorId].commissionRate;
         if (commissionRate > 0) {
-            valReward = valReward.add(reward.sub(valReward).mul(commissionRate).div(MAX_COMMISION_RATE));
+            validatorReward = validatorReward.add(
+                reward.sub(validatorReward).mul(commissionRate).div(MAX_COMMISION_RATE)
+            );
         }
 
-        uint256 delReward = reward.sub(valReward);
-        return (valReward, delReward);
+        uint256 delegatorsReward = reward.sub(validatorReward);
+        return (validatorReward, delegatorsReward);
     }
 
     function _evaluateValidatorAndDelegationReward(uint256 validatorId)
         private
         view
-        returns (uint256 valReward, uint256 delReward)
+        returns (uint256 validatorReward, uint256 delegatorsReward)
     {
         uint256 validatorsStake = validators[validatorId].amount;
         uint256 combinedStakePower = validatorsStake.add(validators[validatorId].delegatedAmount);
         uint256 eligibleReward = rewardPerStake - validators[validatorId].initialRewardPerStake;
-        return _getValidatorAndDelegationReward(
-            validatorId,
-            validatorsStake,
-            eligibleReward.mul(combinedStakePower).div(REWARD_PRECISION),
-            combinedStakePower
-        );
+        return
+            _getValidatorAndDelegationReward(
+                validatorId,
+                validatorsStake,
+                eligibleReward.mul(combinedStakePower).div(REWARD_PRECISION),
+                combinedStakePower
+            );
     }
 
     function _stakeFor(
@@ -983,6 +1084,8 @@ contract StakeManager is
 
         signerToValidator[signer] = validatorId;
         updateTimeline(int256(amount), 1, 0);
+        // no Auctions for 1 dynasty
+        validatorAuction[validatorId].startEpoch = _currentEpoch;
         _logger.logStaked(signer, signerPubkey, validatorId, _currentEpoch, amount, newTotalStaked);
         NFTCounter = validatorId.add(1);
 

--- a/contracts/staking/stakeManager/StakeManagerExtension.sol
+++ b/contracts/staking/stakeManager/StakeManagerExtension.sol
@@ -6,13 +6,13 @@ import {Registry} from "../../common/Registry.sol";
 import {GovernanceLockable} from "../../common/mixin/GovernanceLockable.sol";
 import {IStakeManager} from "./IStakeManager.sol";
 import {StakeManagerStorage} from "./StakeManagerStorage.sol";
-import {StakeManagerStorageExtension} from "./StakeManagerStorageExtension.sol";
+import {StakeManagerStorageExtensionLegacy} from "./StakeManagerStorageExtensionLegacy.sol";
 import {Math} from "../../common/oz/math/Math.sol";
 import {Initializable} from "../../common/mixin/Initializable.sol";
 import {EventsHub} from "../EventsHub.sol";
 import {ValidatorShare} from "../validatorShare/ValidatorShare.sol";
 
-contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManagerStorageExtension {
+contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManagerStorageExtensionLegacy {
     using SafeMath for uint256;
 
     constructor() public GovernanceLockable(address(0x0)) {}

--- a/contracts/staking/stakeManager/StakeManagerExtension.sol
+++ b/contracts/staking/stakeManager/StakeManagerExtension.sol
@@ -1,10 +1,13 @@
 pragma solidity 0.5.17;
 
+import {IERC20} from "../../common/oz/token/ERC20/IERC20.sol";
 import {SafeMath} from "../../common/oz/math/SafeMath.sol";
 import {Registry} from "../../common/Registry.sol";
 import {GovernanceLockable} from "../../common/mixin/GovernanceLockable.sol";
+import {IStakeManager} from "./IStakeManager.sol";
 import {StakeManagerStorage} from "./StakeManagerStorage.sol";
 import {StakeManagerStorageExtension} from "./StakeManagerStorageExtension.sol";
+import {Math} from "../../common/oz/math/Math.sol";
 import {Initializable} from "../../common/mixin/Initializable.sol";
 import {EventsHub} from "../EventsHub.sol";
 import {ValidatorShare} from "../validatorShare/ValidatorShare.sol";
@@ -14,7 +17,115 @@ contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManag
 
     constructor() public GovernanceLockable(address(0x0)) {}
 
-    function migrateValidatorsData(uint256 validatorIdFrom, uint256 validatorIdTo) external {
+    function startAuction(
+        uint256 validatorId,
+        uint256 amount,
+        bool _acceptDelegation,
+        bytes calldata _signerPubkey
+    ) external {
+        uint256 currentValidatorAmount = validators[validatorId].amount;
+
+        require(
+            validators[validatorId].deactivationEpoch == 0 && currentValidatorAmount != 0,
+            "Invalid validator for an auction"
+        );
+        uint256 senderValidatorId = signerToValidator[msg.sender];
+        // make sure that signer wasn't used already
+        require(
+            NFTContract.balanceOf(msg.sender) == 0 && // existing validators can't bid
+                senderValidatorId != INCORRECT_VALIDATOR_ID,
+            "Already used address"
+        );
+
+        uint256 _currentEpoch = currentEpoch;
+        uint256 _replacementCoolDown = replacementCoolDown;
+        // when dynasty period is updated validators are in cooldown period
+        require(_replacementCoolDown == 0 || _replacementCoolDown <= _currentEpoch, "Cooldown period");
+        // (auctionPeriod--dynasty)--(auctionPeriod--dynasty)--(auctionPeriod--dynasty)
+        // if it's auctionPeriod then will get residue smaller then auctionPeriod
+        // from (CurrentPeriod of validator )%(auctionPeriod--dynasty)
+        // make sure that its `auctionPeriod` window
+        // dynasty = 30, auctionPeriod = 7, activationEpoch = 1, currentEpoch = 39
+        // residue 1 = (39-1)% (7+30), if residue <= auctionPeriod it's `auctionPeriod`
+
+        require(
+            (_currentEpoch.sub(validators[validatorId].activationEpoch) % dynasty.add(auctionPeriod)) < auctionPeriod,
+            "Invalid auction period"
+        );
+
+        uint256 perceivedStake = currentValidatorAmount;
+        perceivedStake = perceivedStake.add(validators[validatorId].delegatedAmount);
+
+        Auction storage auction = validatorAuction[validatorId];
+        uint256 currentAuctionAmount = auction.amount;
+
+        perceivedStake = Math.max(perceivedStake, currentAuctionAmount);
+
+        require(perceivedStake < amount, "Must bid higher");
+        require(token.transferFrom(msg.sender, address(this), amount), "Transfer failed");
+
+        //replace prev auction
+        if (currentAuctionAmount != 0) {
+            require(token.transfer(auction.user, currentAuctionAmount), "Bid return failed");
+        }
+
+        // create new auction
+        auction.amount = amount;
+        auction.user = msg.sender;
+        auction.acceptDelegation = _acceptDelegation;
+        auction.signerPubkey = _signerPubkey;
+
+        logger.logStartAuction(validatorId, currentValidatorAmount, amount);
+    }
+
+    function confirmAuctionBid(
+        uint256 validatorId,
+        uint256 heimdallFee, /** for new validator */
+        IStakeManager stakeManager
+    ) external {
+        Auction storage auction = validatorAuction[validatorId];
+        address auctionUser = auction.user;
+
+        require(
+            msg.sender == auctionUser || NFTContract.tokenOfOwnerByIndex(msg.sender, 0) == validatorId,
+            "Only bidder can confirm"
+        );
+
+        uint256 _currentEpoch = currentEpoch;
+        require(
+            _currentEpoch.sub(auction.startEpoch) % auctionPeriod.add(dynasty) >= auctionPeriod,
+            "Not allowed before auctionPeriod"
+        );
+        require(auction.user != address(0x0), "Invalid auction");
+
+        uint256 validatorAmount = validators[validatorId].amount;
+        uint256 perceivedStake = validatorAmount;
+        uint256 auctionAmount = auction.amount;
+
+        perceivedStake = perceivedStake.add(validators[validatorId].delegatedAmount);
+
+        // validator is last auctioner
+        if (perceivedStake >= auctionAmount && validators[validatorId].deactivationEpoch == 0) {
+            require(token.transfer(auctionUser, auctionAmount), "Bid return failed");
+            //cleanup auction data
+            auction.startEpoch = _currentEpoch;
+            logger.logConfirmAuction(validatorId, validatorId, validatorAmount);
+        } else {
+            stakeManager.dethroneAndStake(
+                auctionUser, 
+                heimdallFee,
+                validatorId,
+                auctionAmount,
+                auction.acceptDelegation,
+                auction.signerPubkey
+            );
+        }
+        uint256 startEpoch = auction.startEpoch;
+        delete validatorAuction[validatorId];
+        validatorAuction[validatorId].startEpoch = startEpoch;
+    }
+
+    function migrateValidatorsData(uint256 validatorIdFrom, uint256 validatorIdTo) external {       
         for (uint256 i = validatorIdFrom; i < validatorIdTo; ++i) {
             ValidatorShare contractAddress = ValidatorShare(validators[i].contractAddress);
             if (contractAddress != ValidatorShare(0)) {
@@ -42,9 +153,7 @@ contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManag
         maxRewardedCheckpoints = _maxRewardedCheckpoints;
         checkpointRewardDelta = _checkpointRewardDelta;
 
-        _getOrCacheEventsHub().logRewardParams(
-            _rewardDecreasePerCheckpoint, _maxRewardedCheckpoints, _checkpointRewardDelta
-        );
+        _getOrCacheEventsHub().logRewardParams(_rewardDecreasePerCheckpoint, _maxRewardedCheckpoints, _checkpointRewardDelta);
     }
 
     function updateCommissionRate(uint256 validatorId, uint256 newCommissionRate) external {
@@ -52,20 +161,17 @@ contract StakeManagerExtension is StakeManagerStorage, Initializable, StakeManag
         uint256 _lastCommissionUpdate = validators[validatorId].lastCommissionUpdate;
 
         require( // withdrawalDelay == dynasty
-            (_lastCommissionUpdate.add(WITHDRAWAL_DELAY) <= _epoch) || _lastCommissionUpdate == 0, // For initial
-                // setting of commission rate
+            (_lastCommissionUpdate.add(WITHDRAWAL_DELAY) <= _epoch) || _lastCommissionUpdate == 0, // For initial setting of commission rate
             "Cooldown"
         );
 
         require(newCommissionRate <= MAX_COMMISION_RATE, "Incorrect value");
-        _getOrCacheEventsHub().logUpdateCommissionRate(
-            validatorId, newCommissionRate, validators[validatorId].commissionRate
-        );
+        _getOrCacheEventsHub().logUpdateCommissionRate(validatorId, newCommissionRate, validators[validatorId].commissionRate);
         validators[validatorId].commissionRate = newCommissionRate;
         validators[validatorId].lastCommissionUpdate = _epoch;
     }
 
-    function _getOrCacheEventsHub() private returns (EventsHub) {
+    function _getOrCacheEventsHub() private returns(EventsHub) {
         EventsHub _eventsHub = EventsHub(eventsHub);
         if (_eventsHub == EventsHub(0x0)) {
             _eventsHub = EventsHub(Registry(registry).contractMap(keccak256("eventsHub")));

--- a/contracts/staking/stakeManager/StakeManagerStorageExtension.sol
+++ b/contracts/staking/stakeManager/StakeManagerStorageExtension.sol
@@ -2,22 +2,15 @@ pragma solidity 0.5.17;
 
 import {IPolygonMigration} from "../../common/misc/IPolygonMigration.sol";
 import {IERC20} from "../../common/oz/token/ERC20/IERC20.sol";
+import {StakeManagerStorageExtensionLegacy} from "./StakeManagerStorageExtensionLegacy.sol";
 
-contract StakeManagerStorageExtension {
-    address public eventsHub;
-    uint256 public rewardPerStake;
-    address public extensionCode;
-    address[] public signers;
-
-    uint256 internal constant CHK_REWARD_PRECISION = 100;
-    uint256 public prevBlockInterval;
-    // how much less reward per skipped checkpoint, 0 - 100%
-    uint256 public rewardDecreasePerCheckpoint;
-    // how many checkpoints to reward
-    uint256 public maxRewardedCheckpoints;
-    // increase / decrease value for faster or slower checkpoints, 0 - 100%
-    uint256 public checkpointRewardDelta;
-
+// Layout used by the deployed `StakeManager` implementation
+// (0x3AD88467E40399dc6Ae10427f8B0842348d9076c): the pre-POL prefix in
+// `StakeManagerStorageExtensionLegacy` plus the two POL slots added for the MATIC->POL migration.
+//
+// The extension deployed at 0xef49Ea6996073752b6840CDA34773FFA78F78166 predates those two slots and
+// therefore inherits the Legacy base directly. See StakeManagerStorageExtensionLegacy.sol.
+contract StakeManagerStorageExtension is StakeManagerStorageExtensionLegacy {
     IERC20 public tokenMatic;
     IPolygonMigration public migration;
 }

--- a/contracts/staking/stakeManager/StakeManagerStorageExtensionLegacy.sol
+++ b/contracts/staking/stakeManager/StakeManagerStorageExtensionLegacy.sol
@@ -1,0 +1,31 @@
+pragma solidity 0.5.17;
+
+// FROZEN — reproduces the deployed `StakeManagerExtension` (0xef49Ea6996073752b6840CDA34773FFA78F78166).
+//
+// The live StakeManager pair straddles the POL storage addition: the deployed StakeManager
+// implementation (0x3AD88467E40399dc6Ae10427f8B0842348d9076c, 2024) carries the two POL slots
+// `tokenMatic`/`migration`, while the extension it delegates to was deployed in 2021 and predates
+// them. Because the extension declares `public` state, those two slots would emit two extra
+// getters into its runtime bytecode and it would no longer reproduce on-chain.
+//
+// This contract is the pre-POL layout. `StakeManagerStorageExtension` extends it with the two POL
+// slots, so the shared prefix is defined exactly once and cannot drift between the two. Appending
+// in the derived contract keeps every slot in this file at the same position for both.
+//
+// Do not add state here. New storage belongs in `StakeManagerStorageExtension`; adding it here
+// would shift the POL slots and break the deployed StakeManager.
+contract StakeManagerStorageExtensionLegacy {
+    address public eventsHub;
+    uint256 public rewardPerStake;
+    address public extensionCode;
+    address[] public signers;
+
+    uint256 internal constant CHK_REWARD_PRECISION = 100;
+    uint256 public prevBlockInterval;
+    // how much less reward per skipped checkpoint, 0 - 100%
+    uint256 public rewardDecreasePerCheckpoint;
+    // how many checkpoints to reward
+    uint256 public maxRewardedCheckpoints;
+    // increase / decrease value for faster or slower checkpoints, 0 - 100%
+    uint256 public checkpointRewardDelta;
+}

--- a/script/pinning/compare_bytecode.py
+++ b/script/pinning/compare_bytecode.py
@@ -71,6 +71,20 @@ def main():
             continue
         entry = {k: c[k] for k in ("chain", "name", "address", "artifact", "solc", "file")}
 
+        # Pointer liveness (fetched by verify-bytecode.sh step 2b). If the live system no longer
+        # points at the address we pin, that address still holds the same immutable bytecode, so
+        # comparing it would pass while telling us nothing about what is actually deployed. Report
+        # the drift instead; the fix is to repoint the inventory and re-run.
+        if c.get("liveness"):
+            live_path = os.path.join(work, "liveness", f"{c['chain']}_{c['address'].lower()}.addr")
+            resolved = open(live_path).read().strip() if os.path.exists(live_path) else ""
+            if resolved.lower() != c["address"].lower():
+                entry["status"] = "STALE_POINTER"
+                entry["points_at"] = resolved or "(unresolved)"
+                entry["liveness"] = c["liveness"]
+                results.append(entry)
+                continue
+
         src_base = os.path.basename(c["file"])
         # Must mirror verify-bytecode.sh's cache layout, including the bor-chain-id
         # level: the same file+solc can be built at two different chain ids.
@@ -143,11 +157,20 @@ def main():
     width = max(len(r["name"]) for r in results) + 2
     print(f"\n{'CONTRACT':<{width}}{'CHAIN':<7}{'SOLC':<9}STATUS")
     print("-" * (width + 30))
-    rank = {"MISMATCH": 0, "MISSING_ARTIFACT": 1, "NO_CODE": 2, "MATCH_NO_META": 3, "MATCH": 4}
+    rank = {
+        "MISMATCH": 0,
+        "STALE_POINTER": 1,
+        "MISSING_ARTIFACT": 2,
+        "NO_CODE": 3,
+        "MATCH_NO_META": 4,
+        "MATCH": 5,
+    }
     for r in sorted(results, key=lambda r: (rank[r["status"]], r["chain"], r["name"])):
         extra = ""
         if r["status"] == "MISMATCH":
             extra = f"  (len {r['len_local']} vs {r['len_onchain']}, first diff @{r['first_diff_offset']})"
+        elif r["status"] == "STALE_POINTER":
+            extra = f"  ({r['liveness']['sig']} now returns {r['points_at']})"
         print(f"{r['name']:<{width}}{r['chain']:<7}{r['solc']:<9}{r['status']}{extra}")
 
     bad = [r for r in results if r["status"] not in ("MATCH", "MATCH_NO_META")]

--- a/script/pinning/compare_bytecode.py
+++ b/script/pinning/compare_bytecode.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Compare locally compiled runtime bytecode against on-chain runtime bytecode.
+
+Invoked by verify-bytecode.sh. For each pinned contract it reads
+  - the forge artifact from <work>/build/out-<solc>/<File>.sol/<Artifact>.json
+  - the cached on-chain code from <work>/onchain/<chain>_<address>.hex
+
+Comparison levels:
+  MATCH            byte-for-byte identical
+  MATCH_NO_META    identical after stripping the trailing CBOR metadata blob
+                   (source was reformatted/commented but compiles to the same logic)
+  MISMATCH         logic bytecode differs; both stripped blobs are dumped to <work>/diffs/
+  NO_CODE          address has no code on-chain
+  MISSING_ARTIFACT local build did not produce the expected artifact
+
+Library deployments have their own address embedded at byte offset 1 (PUSH20),
+which is masked on both sides. Unresolved link references are masked the same way.
+"""
+
+import json
+import os
+import sys
+
+
+def strip_metadata(code: bytes):
+    """Split trailing CBOR metadata (solidity appends <cbor><2-byte length>)."""
+    if len(code) < 4:
+        return code, b""
+    length = int.from_bytes(code[-2:], "big")
+    if length + 2 > len(code):
+        return code, b""
+    meta = code[-(length + 2):]
+    # sanity: solidity metadata is a small CBOR map starting with 0xa1/0xa2/0xa3
+    if meta[0] not in (0xA1, 0xA2, 0xA3):
+        return code, b""
+    return code[: -(length + 2)], meta
+
+
+def mask(code: bytearray, start: int, length: int):
+    code[start : start + length] = b"\x00" * length
+
+
+def mask_embedded_metadata(code: bytearray) -> int:
+    """Zero metadata hashes embedded mid-stream (factories carry the creation
+    code of child contracts, which ends in its own CBOR metadata blob)."""
+    markers = [
+        (b"\xa2\x65\x62\x7a\x7a\x72\x30\x58\x20", 32),  # bzzr0 (solc <= 0.5.11)
+        (b"\xa2\x65\x62\x7a\x7a\x72\x31\x58\x20", 32),  # bzzr1 (solc 0.5.12+)
+        (b"\xa2\x64\x69\x70\x66\x73\x58\x22", 34),      # ipfs  (solc 0.6+/foundry default)
+    ]
+    hits = 0
+    for marker, hash_len in markers:
+        start = 0
+        while (pos := bytes(code).find(marker, start)) != -1:
+            mask(code, pos + len(marker), hash_len)
+            start = pos + len(marker) + hash_len
+            hits += 1
+    return hits
+
+
+def main():
+    config_path, work = sys.argv[1], sys.argv[2]
+    chains = sys.argv[3:]
+    cfg = json.load(open(config_path))
+    results = []
+
+    for c in cfg["contracts"]:
+        if chains and c["chain"] not in chains:
+            continue
+        if c.get("exclude"):  # legacy / not pinnable to current source — see note
+            continue
+        entry = {k: c[k] for k in ("chain", "name", "address", "artifact", "solc", "file")}
+
+        src_base = os.path.basename(c["file"])
+        # Must mirror verify-bytecode.sh's cache layout, including the bor-chain-id
+        # level: the same file+solc can be built at two different chain ids.
+        art_path = os.path.join(
+            work, "artifacts", c.get("borChainId", "137"), c["solc"], src_base, c["artifact"] + ".json"
+        )
+        onchain_path = os.path.join(
+            work, "onchain", f"{c['chain']}_{c['address'].lower()}.hex"
+        )
+
+        if not os.path.exists(art_path):
+            entry["status"] = "MISSING_ARTIFACT"
+            results.append(entry)
+            continue
+
+        art = json.load(open(art_path))
+        local_hex = art["deployedBytecode"]["object"].removeprefix("0x")
+        onchain_hex = open(onchain_path).read().strip().removeprefix("0x").lower()
+
+        if not onchain_hex:
+            entry["status"] = "NO_CODE"
+            results.append(entry)
+            continue
+
+        # mask placeholders for unresolved library links on both sides
+        local_b = bytearray.fromhex(local_hex.replace("_", "0").replace("$", "0"))
+        onchain_b = bytearray.fromhex(onchain_hex)
+        for refs in art["deployedBytecode"].get("linkReferences", {}).values():
+            for sites in refs.values():
+                for site in sites:
+                    mask(local_b, site["start"], site["length"])
+                    if site["start"] + site["length"] <= len(onchain_b):
+                        mask(onchain_b, site["start"], site["length"])
+        if c.get("isLibrary") and len(local_b) > 21 and len(onchain_b) > 21:
+            mask(local_b, 1, 20)  # deployed libraries embed their own address here
+            mask(onchain_b, 1, 20)
+
+        if local_b == onchain_b:
+            entry["status"] = "MATCH"
+        else:
+            stripped_local, local_meta = strip_metadata(bytes(local_b))
+            stripped_onchain, onchain_meta = strip_metadata(bytes(onchain_b))
+            # embedded child-creation-code metadata (factories) is metadata too
+            local_logic, onchain_logic = bytearray(stripped_local), bytearray(stripped_onchain)
+            mask_embedded_metadata(local_logic)
+            mask_embedded_metadata(onchain_logic)
+            if local_logic == onchain_logic:
+                entry["status"] = "MATCH_NO_META"
+                entry["meta_local"] = local_meta.hex()
+                entry["meta_onchain"] = onchain_meta.hex()
+            else:
+                entry["status"] = "MISMATCH"
+                entry["len_local"] = len(local_logic)
+                entry["len_onchain"] = len(onchain_logic)
+                first_diff = next(
+                    (i for i, (a, b) in enumerate(zip(local_logic, onchain_logic)) if a != b),
+                    min(len(local_logic), len(onchain_logic)),
+                )
+                entry["first_diff_offset"] = first_diff
+                tag = f"{c['chain']}_{c['artifact']}"
+                os.makedirs(os.path.join(work, "diffs"), exist_ok=True)
+                for suffix, blob in (("local", local_logic), ("onchain", onchain_logic)):
+                    with open(os.path.join(work, "diffs", f"{tag}.{suffix}.hex"), "w") as f:
+                        f.write(blob.hex())
+        results.append(entry)
+
+    with open(os.path.join(work, "results.json"), "w") as f:
+        json.dump(results, f, indent=2)
+
+    width = max(len(r["name"]) for r in results) + 2
+    print(f"\n{'CONTRACT':<{width}}{'CHAIN':<7}{'SOLC':<9}STATUS")
+    print("-" * (width + 30))
+    rank = {"MISMATCH": 0, "MISSING_ARTIFACT": 1, "NO_CODE": 2, "MATCH_NO_META": 3, "MATCH": 4}
+    for r in sorted(results, key=lambda r: (rank[r["status"]], r["chain"], r["name"])):
+        extra = ""
+        if r["status"] == "MISMATCH":
+            extra = f"  (len {r['len_local']} vs {r['len_onchain']}, first diff @{r['first_diff_offset']})"
+        print(f"{r['name']:<{width}}{r['chain']:<7}{r['solc']:<9}{r['status']}{extra}")
+
+    bad = [r for r in results if r["status"] not in ("MATCH", "MATCH_NO_META")]
+    meta_only = [r for r in results if r["status"] == "MATCH_NO_META"]
+    print(
+        f"\n{len(results)} checked: {len(results) - len(bad) - len(meta_only)} exact, "
+        f"{len(meta_only)} metadata-only diff, {len(bad)} problems"
+    )
+    sys.exit(1 if bad else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/pinning/compare_bytecode.py
+++ b/script/pinning/compare_bytecode.py
@@ -6,12 +6,18 @@ Invoked by verify-bytecode.sh. For each pinned contract it reads
   - the cached on-chain code from <work>/onchain/<chain>_<address>.hex
 
 Comparison levels:
-  MATCH            byte-for-byte identical
-  MATCH_NO_META    identical after stripping the trailing CBOR metadata blob
-                   (source was reformatted/commented but compiles to the same logic)
-  MISMATCH         logic bytecode differs; both stripped blobs are dumped to <work>/diffs/
-  NO_CODE          address has no code on-chain
-  MISSING_ARTIFACT local build did not produce the expected artifact
+  MATCH              byte-for-byte identical
+  MATCH_NO_META      identical after stripping the trailing CBOR metadata blob
+                     (source was reformatted/commented but compiles to the same logic)
+  MISMATCH           logic bytecode differs; both stripped blobs are dumped to <work>/diffs/
+  STALE_POINTER      the live system no longer points at this address (see 'liveness')
+  POINTER_UNRESOLVED the liveness call could not be read at all — usually a flaky RPC, NOT
+                     evidence of drift. Kept distinct from STALE_POINTER so a transient
+                     failure is never mistaken for a real proxy upgrade, and vice versa.
+  NO_CODE            address has no code on-chain
+  MISSING_ARTIFACT   local build did not produce the expected artifact
+
+Everything except MATCH and MATCH_NO_META is a failure and exits non-zero.
 
 Library deployments have their own address embedded at byte offset 1 (PUSH20),
 which is masked on both sides. Unresolved link references are masked the same way.
@@ -19,6 +25,7 @@ which is masked on both sides. Unresolved link references are masked the same wa
 
 import json
 import os
+import re
 import sys
 
 
@@ -78,9 +85,17 @@ def main():
         if c.get("liveness"):
             live_path = os.path.join(work, "liveness", f"{c['chain']}_{c['address'].lower()}.addr")
             resolved = open(live_path).read().strip() if os.path.exists(live_path) else ""
+            if not re.fullmatch(r"0x[0-9a-fA-F]{40}", resolved):
+                # No address came back (RPC error, reverted call, sentinel from the shell). This is
+                # a failure to CHECK, not a detected drift — do not cry proxy upgrade.
+                entry["status"] = "POINTER_UNRESOLVED"
+                entry["points_at"] = resolved or "(empty)"
+                entry["liveness"] = c["liveness"]
+                results.append(entry)
+                continue
             if resolved.lower() != c["address"].lower():
                 entry["status"] = "STALE_POINTER"
-                entry["points_at"] = resolved or "(unresolved)"
+                entry["points_at"] = resolved
                 entry["liveness"] = c["liveness"]
                 results.append(entry)
                 continue
@@ -151,6 +166,13 @@ def main():
                         f.write(blob.hex())
         results.append(entry)
 
+    # Verifying nothing is not success. A typo'd chain filter or an inventory that lost its entries
+    # would otherwise report a clean run, which is the one way this script could lie.
+    if not results:
+        sys.exit(
+            f"error: no inventory entries matched (chains requested: {', '.join(chains) or 'all'})"
+        )
+
     with open(os.path.join(work, "results.json"), "w") as f:
         json.dump(results, f, indent=2)
 
@@ -162,8 +184,9 @@ def main():
         "STALE_POINTER": 1,
         "MISSING_ARTIFACT": 2,
         "NO_CODE": 3,
-        "MATCH_NO_META": 4,
-        "MATCH": 5,
+        "POINTER_UNRESOLVED": 4,
+        "MATCH_NO_META": 5,
+        "MATCH": 6,
     }
     for r in sorted(results, key=lambda r: (rank[r["status"]], r["chain"], r["name"])):
         extra = ""
@@ -171,6 +194,8 @@ def main():
             extra = f"  (len {r['len_local']} vs {r['len_onchain']}, first diff @{r['first_diff_offset']})"
         elif r["status"] == "STALE_POINTER":
             extra = f"  ({r['liveness']['sig']} now returns {r['points_at']})"
+        elif r["status"] == "POINTER_UNRESOLVED":
+            extra = f"  (could not read {r['liveness']['sig']} on {r['liveness']['target']} — retry)"
         print(f"{r['name']:<{width}}{r['chain']:<7}{r['solc']:<9}{r['status']}{extra}")
 
     bad = [r for r in results if r["status"] not in ("MATCH", "MATCH_NO_META")]

--- a/script/pinning/pinned-contracts.json
+++ b/script/pinning/pinned-contracts.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Non-upgradeable (pinned) contracts: deployed bytecode at these addresses can never change, so the repo sources must always compile to exactly this bytecode. 'solc' is the compiler version the contract was deployed with (from Etherscan verified metadata). 'borChainId' (optional) pins the ChainIdMixin template value for contracts that embed it — it is per-contract, not global: read networkId()/CHAINID() from the live contract (0x89=137, 0x3a99=15001) and set it here; the verifier renders tools/process-templates.cjs -c <borChainId> before building. Entries without borChainId do not embed ChainIdMixin and build identically regardless. 'exclude':true entries are documented but skipped (legacy / not pinnable to current source). 'unverified' = no verified source on the explorer; artifact mapping is a best guess. 'upgradeable':true entries are implementations reached through a proxy or a Registry lookup: they are replaceable, so they are not pins in the strict sense, but they are verified informationally — the repo should reproduce whatever is live today. Deployed-but-out-of-repo contracts (POL token suite, Timelock, EIP1559Burn, WMATIC, L1 MaticToken) are tracked in their own repos.",
+  "_comment": "Non-upgradeable (pinned) contracts: deployed bytecode at these addresses can never change, so the repo sources must always compile to exactly this bytecode. 'solc' is the compiler version the contract was deployed with (from Etherscan verified metadata). 'borChainId' (optional) pins the ChainIdMixin template value for contracts that embed it — it is per-contract, not global: read networkId()/CHAINID() from the live contract (0x89=137, 0x3a99=15001) and set it here; the verifier renders tools/process-templates.cjs -c <borChainId> before building. Entries without borChainId do not embed ChainIdMixin and build identically regardless. 'exclude':true entries are documented but skipped (legacy / not pinnable to current source). 'unverified' = no verified source on the explorer; artifact mapping is a best guess. 'upgradeable':true entries are implementations reached through a proxy or a Registry lookup: they are replaceable, so they are not pins in the strict sense, but they are verified informationally — the repo should reproduce whatever is live today. 'liveness' (optional) guards against the system being re-pointed at a DIFFERENT address: 'target'+'sig' is a call whose returned address must still equal this entry's 'address'. Bytecode at a fixed address is immutable, so the bytecode comparison alone can never catch a proxy upgrade or a Registry re-registration — it has already happened once (Registry.erc20Predicate moved 0x626fb210... -> 0x4EeA1780...). Add it to anything reached through a pointer. Deployed-but-out-of-repo contracts (POL token suite, Timelock, EIP1559Burn, WMATIC, L1 MaticToken) are tracked in their own repos.",
   "rpc": {
     "1": "mainnet",
     "137": "polygon_pos"
@@ -155,6 +155,10 @@
       "artifact": "ERC20PredicateBurnOnly",
       "solc": "0.5.17",
       "borChainId": "137",
+      "liveness": {
+        "target": "0x33a02E6cC863D393d6Bf231B697b82F6e499cA71",
+        "sig": "erc20Predicate()(address)"
+      },
       "note": "ADDRESS CORRECTED: Registry.erc20Predicate() returns 0x4EeA1780..., a NEWER deployment with the log limit removed. The older 0x626fb210... predicate is no longer registered. Embeds ChainIdMixin (via IPredicate); deployed networkId()=0x89 → bor-chain-id 137 (unlike the original 2020 ERC721 predicate, which is 15001). Matches repo logic exactly once built with 137."
     },
     {
@@ -165,6 +169,10 @@
       "artifact": "ERC721PredicateBurnOnly",
       "solc": "0.5.17",
       "borChainId": "15001",
+      "liveness": {
+        "target": "0x33a02E6cC863D393d6Bf231B697b82F6e499cA71",
+        "sig": "erc721Predicate()(address)"
+      },
       "note": "Original 2020 deployment. Embeds ChainIdMixin (via IPredicate); deployed networkId()=0x3a99 → build with bor-chain-id 15001 (the Mumbai-era default), NOT 137."
     },
     {
@@ -248,6 +256,10 @@
       "borChainId": "137",
       "upgradeable": true,
       "unverified": true,
+      "liveness": {
+        "target": "0x84000b263080BC37D1DD73A29D92794A6CF1564e",
+        "sig": "implementation()(address)"
+      },
       "note": "UPGRADEABLE impl behind ChildTokenProxy 0x84000b26… (the current DAI child). Unverified on Polygonscan; identified by bytecode. Deployed networkId()=0x89 → bor-chain-id 137. Same source as the deprecated impl 0xa45b96… — the only bytecode difference is the 3-byte ChainIdMixin constant, which is very likely why DAI was redeployed and remapped. Reproduces only with the pre-POL-rename EIP712 domain; see contracts/child/misc/EIP712.sol."
     },
     {
@@ -260,6 +272,10 @@
       "borChainId": "15001",
       "upgradeable": true,
       "unverified": true,
+      "liveness": {
+        "target": "0x1FF58e665531953a3C667E2D831586777fE4Be31",
+        "sig": "implementation()(address)"
+      },
       "note": "UPGRADEABLE impl behind ChildTokenProxy 0x1FF58e66… (LORD). Unverified on Polygonscan; identified by bytecode. Deployed networkId()=0x3a99 → bor-chain-id 15001 — still the Mumbai-era value, unlike the current DAI impl which was moved to 137."
     },
     {
@@ -270,6 +286,10 @@
       "artifact": "DepositManager",
       "solc": "0.5.17",
       "upgradeable": true,
+      "liveness": {
+        "target": "0x401F6c983eA34274ec46f84D70b31C151321188b",
+        "sig": "implementation()(address)"
+      },
       "note": "UPGRADEABLE impl behind DepositManagerProxy. Not an immutable pin — verified informationally (repo should reproduce the current impl). Uses the modern GovernanceLockable/Governable bases."
     },
     {
@@ -280,6 +300,10 @@
       "artifact": "WithdrawManager",
       "solc": "0.5.17",
       "upgradeable": true,
+      "liveness": {
+        "target": "0x2A88696e0fFA76bAA1338F2C74497cC013495922",
+        "sig": "implementation()(address)"
+      },
       "note": "UPGRADEABLE impl behind WithdrawManagerProxy. This is the impl the proxy points at today; the older 0x31f9… address is stale."
     },
     {
@@ -291,6 +315,10 @@
       "solc": "0.5.17",
       "borChainId": "137",
       "upgradeable": true,
+      "liveness": {
+        "target": "0x86E4Dc95c7FBdBf52e33D563BbDB00823894C287",
+        "sig": "implementation()(address)"
+      },
       "note": "UPGRADEABLE impl behind RootChainProxy (chain-id 137). Reproduces from current source. NOTE: RootChain.sol keeps an empty no-op `function slash() {}` solely to match this deployed impl, which still has it (the slash removal 0c08057a is not yet deployed to RootChain) — that no-op is marked for deletion on the next RootChain redeploy."
     },
     {
@@ -301,6 +329,10 @@
       "artifact": "Governance",
       "solc": "0.5.11",
       "upgradeable": true,
+      "liveness": {
+        "target": "0x6e7a5820baD6cebA8Ef5ea69c0C92EbbDAc9CE48",
+        "sig": "implementation()(address)"
+      },
       "note": "UPGRADEABLE impl behind GovernanceProxy."
     },
     {
@@ -311,6 +343,10 @@
       "artifact": "ValidatorShare",
       "solc": "0.5.17",
       "upgradeable": true,
+      "liveness": {
+        "target": "0x33a02E6cC863D393d6Bf231B697b82F6e499cA71",
+        "sig": "getValidatorShareAddress()(address)"
+      },
       "note": "UPGRADEABLE impl, current one registered via Registry.getValidatorShareAddress() (all ValidatorShareProxy instances delegate to it); the older 0x053FA9b9… address is stale. Reproduces from current repo source."
     },
     {
@@ -321,6 +357,10 @@
       "artifact": "StakeManager",
       "solc": "0.5.17",
       "upgradeable": true,
+      "liveness": {
+        "target": "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
+        "sig": "implementation()(address)"
+      },
       "note": "UPGRADEABLE impl behind StakeManagerProxy, deployed 2024-10-30, 24212 bytes. Reproduces from current source: main was reverted to this deployed version (built from 5b7e40e5) so the repo mirrors the chain. It was deployed with the 9-argument `initialize` and migrated to POL afterwards by a separate governance `initializePOL` call — the POL-aware initializer was never deployed, so the deploy/test harnesses run that two-step sequence. Delegates to the StakeManagerExtension below, which predates the two POL storage slots; see StakeManagerStorageExtensionLegacy.sol."
     },
     {
@@ -331,6 +371,10 @@
       "artifact": "StakeManagerExtension",
       "solc": "0.5.17",
       "upgradeable": true,
+      "liveness": {
+        "target": "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
+        "sig": "extensionCode()(address)"
+      },
       "note": "UPGRADEABLE `extensionCode` that the StakeManager delegates to, deployed 2021-03-26 (truffle era), 7653 bytes. Reproduces from current source (built from a1e3e275). It predates the MATIC->POL migration, so it inherits StakeManagerStorageExtensionLegacy (the pre-POL prefix) rather than StakeManagerStorageExtension: because it declares public state, inheriting the two POL slots would emit two extra getters into its runtime and it would no longer reproduce."
     }
   ]

--- a/script/pinning/pinned-contracts.json
+++ b/script/pinning/pinned-contracts.json
@@ -1,0 +1,313 @@
+{
+  "_comment": "Non-upgradeable (pinned) contracts: deployed bytecode at these addresses can never change, so the repo sources must always compile to exactly this bytecode. 'solc' is the compiler version the contract was deployed with (from Etherscan verified metadata). 'borChainId' (optional) pins the ChainIdMixin template value for contracts that embed it — it is per-contract, not global: read networkId()/CHAINID() from the live contract (0x89=137, 0x3a99=15001) and set it here; the verifier renders tools/process-templates.cjs -c <borChainId> before building. Entries without borChainId do not embed ChainIdMixin and build identically regardless. 'exclude':true entries are documented but skipped (legacy / not pinnable to current source). 'unverified' = no verified source on the explorer; artifact mapping is a best guess. 'upgradeable':true entries are implementations reached through a proxy or a Registry lookup: they are replaceable, so they are not pins in the strict sense, but they are verified informationally — the repo should reproduce whatever is live today. Deployed-but-out-of-repo contracts (POL token suite, Timelock, EIP1559Burn, WMATIC, L1 MaticToken) are tracked in their own repos.",
+  "rpc": {
+    "1": "mainnet",
+    "137": "polygon_pos"
+  },
+  "contracts": [
+    {
+      "chain": "1",
+      "name": "Registry",
+      "address": "0x33a02E6cC863D393d6Bf231B697b82F6e499cA71",
+      "file": "contracts/common/Registry.sol",
+      "artifact": "Registry",
+      "solc": "0.5.11",
+      "note": "Registry (single immutable deployment) inherits GovernableLegacy (contracts/common/governance/GovernableLegacy.sol), the pre-49b39d8a inlined onlyGovernance. The modern Governable (_assertGovernance) is kept for the live impls that use it. Reproduces byte-for-byte under a normal forge build."
+    },
+    {
+      "chain": "1",
+      "name": "GovernanceProxy",
+      "address": "0x6e7a5820baD6cebA8Ef5ea69c0C92EbbDAc9CE48",
+      "file": "contracts/common/governance/GovernanceProxy.sol",
+      "artifact": "GovernanceProxy",
+      "solc": "0.5.11"
+    },
+    {
+      "chain": "1",
+      "name": "RootChainProxy",
+      "address": "0x86E4Dc95c7FBdBf52e33D563BbDB00823894C287",
+      "file": "contracts/root/RootChainProxy.sol",
+      "artifact": "RootChainProxy",
+      "solc": "0.5.11",
+      "borChainId": "137",
+      "note": "Embeds ChainIdMixin (via RootChainStorage). Deployed networkId()=0x89 → build with bor-chain-id 137."
+    },
+    {
+      "chain": "1",
+      "name": "StateSender",
+      "address": "0x28e4F3a7f651294B9564800b2D01f35189A5bFbE",
+      "file": "contracts/root/stateSyncer/StateSender.sol",
+      "artifact": "StateSender",
+      "solc": "0.5.11"
+    },
+    {
+      "chain": "1",
+      "name": "DepositManagerProxy",
+      "address": "0x401F6c983eA34274ec46f84D70b31C151321188b",
+      "file": "contracts/root/depositManager/DepositManagerProxy.sol",
+      "artifact": "DepositManagerProxy",
+      "solc": "0.5.11",
+      "note": "The proxy (single immutable deployment) inherits DepositManagerStorageLegacy -> LockableLegacy (locked at slot 2), the pre-d0cbfb42 layout. The modern Lockable/GovernanceLockable (locked at slot 1) is kept for the live impl. Reproduces byte-for-byte under a normal forge build. Both layouts must coexist and neither may be re-pointed at the other's bases — see the comments in LockableLegacy.sol and DepositManagerStorageLegacy.sol."
+    },
+    {
+      "chain": "1",
+      "name": "WithdrawManagerProxy",
+      "address": "0x2A88696e0fFA76bAA1338F2C74497cC013495922",
+      "file": "contracts/root/withdrawManager/WithdrawManagerProxy.sol",
+      "artifact": "WithdrawManagerProxy",
+      "solc": "0.5.11"
+    },
+    {
+      "chain": "1",
+      "name": "ExitNFT",
+      "address": "0xDF74156420Bd57ab387B195ed81EcA36F9fABAca",
+      "file": "contracts/root/withdrawManager/ExitNFT.sol",
+      "artifact": "ExitNFT",
+      "solc": "0.5.11"
+    },
+    {
+      "chain": "1",
+      "name": "PriorityQueue",
+      "address": "0x61AdDcD534Bdc1721c91740Cf711dBEcE936053e",
+      "file": "contracts/common/lib/PriorityQueue.sol",
+      "artifact": "PriorityQueue",
+      "solc": "0.5.11",
+      "isLibrary": true
+    },
+    {
+      "chain": "1",
+      "name": "MaticWETH",
+      "address": "0xa45b966996374E9e65ab991C6FE4Bfce3a56DDe8",
+      "file": "contracts/common/tokens/MaticWETH.sol",
+      "artifact": "MaticWETH",
+      "solc": "0.5.11"
+    },
+    {
+      "chain": "1",
+      "name": "TestToken",
+      "address": "0x3db715989dA05C1D17441683B5b41d4510512722",
+      "file": "contracts/common/tokens/TestToken.sol",
+      "artifact": "TestToken",
+      "solc": "0.5.11"
+    },
+    {
+      "chain": "1",
+      "name": "RootERC721",
+      "address": "0x96CDDF45C0Cd9a59876A2a29029d7c54f6e54AD3",
+      "file": "contracts/common/tokens/RootERC721.sol",
+      "artifact": "RootERC721",
+      "solc": "0.5.11"
+    },
+    {
+      "chain": "1",
+      "name": "StakeManagerProxy",
+      "address": "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
+      "file": "contracts/staking/stakeManager/StakeManagerProxy.sol",
+      "artifact": "StakeManagerProxy",
+      "solc": "0.5.17"
+    },
+    {
+      "chain": "1",
+      "name": "EventsHubProxy",
+      "address": "0x6dF5CB08d3f0193C768C8A01f42ac4424DC5086b",
+      "file": "contracts/staking/EventsHubProxy.sol",
+      "artifact": "EventsHubProxy",
+      "solc": "0.5.17"
+    },
+    {
+      "chain": "1",
+      "name": "StakingInfo",
+      "address": "0xa59C847Bd5aC0172Ff4FE912C5d29E5A71A7512B",
+      "file": "contracts/staking/StakingInfo.sol",
+      "artifact": "StakingInfo",
+      "solc": "0.5.17"
+    },
+    {
+      "chain": "1",
+      "name": "StakingNFT",
+      "address": "0x47Cbe25BbDB40a774cC37E1dA92d10C2C7Ec897F",
+      "file": "contracts/staking/stakeManager/StakingNFT.sol",
+      "artifact": "StakingNFT",
+      "solc": "0.5.17"
+    },
+    {
+      "chain": "1",
+      "name": "ValidatorShareFactory",
+      "address": "0xc4FA447A0e77Eff9717b09C057B40570813bb642",
+      "file": "contracts/staking/validatorShare/ValidatorShareFactory.sol",
+      "artifact": "ValidatorShareFactory",
+      "solc": "0.5.17"
+    },
+    {
+      "chain": "1",
+      "name": "ValidatorShareProxy (instance, validator 8)",
+      "address": "0xF74A300e3adE7e50BB807a6F706DC5eB4e8cA540",
+      "file": "contracts/staking/validatorShare/ValidatorShareProxy.sol",
+      "artifact": "ValidatorShareProxy",
+      "solc": "0.5.17",
+      "note": "Factory-deployed instance; creation code is baked into the deployed ValidatorShareFactory, every instance shares this runtime code."
+    },
+    {
+      "chain": "1",
+      "name": "ERC20PredicateBurnOnly",
+      "address": "0x4EeA1780c06709D7FA0BCaA6D0f1aB29673586c0",
+      "file": "contracts/root/predicates/ERC20PredicateBurnOnly.sol",
+      "artifact": "ERC20PredicateBurnOnly",
+      "solc": "0.5.17",
+      "borChainId": "137",
+      "note": "ADDRESS CORRECTED: Registry.erc20Predicate() returns 0x4EeA1780..., a NEWER deployment with the log limit removed. The older 0x626fb210... predicate is no longer registered. Embeds ChainIdMixin (via IPredicate); deployed networkId()=0x89 → bor-chain-id 137 (unlike the original 2020 ERC721 predicate, which is 15001). Matches repo logic exactly once built with 137."
+    },
+    {
+      "chain": "1",
+      "name": "ERC721PredicateBurnOnly",
+      "address": "0x36C2503d53C6948331144b85D1e74a3B96731d1b",
+      "file": "contracts/root/predicates/ERC721PredicateBurnOnly.sol",
+      "artifact": "ERC721PredicateBurnOnly",
+      "solc": "0.5.17",
+      "borChainId": "15001",
+      "note": "Original 2020 deployment. Embeds ChainIdMixin (via IPredicate); deployed networkId()=0x3a99 → build with bor-chain-id 15001 (the Mumbai-era default), NOT 137."
+    },
+    {
+      "chain": "137",
+      "name": "ChildChain",
+      "address": "0xD9c7C4ED4B66858301D0cb28Cc88bf655Fe34861",
+      "file": "contracts/child/ChildChain.sol",
+      "artifact": "ChildChain",
+      "solc": "0.5.11",
+      "borChainId": "137",
+      "note": "Immutable plasma factory. Its bytecode embeds the CREATION code of the OLD ChildERC20/ChildERC721. ChildChain.sol now imports the frozen contracts/child/legacy/* token chain (aliased), so it reproduces byte-for-byte. The modern/proxified token code (live for DAI/LORD) is untouched. Embeds ChainIdMixin CHAINID=137."
+    },
+    {
+      "chain": "137",
+      "name": "MRC20 (genesis 0x1010)",
+      "address": "0x0000000000000000000000000000000000001010",
+      "file": "contracts/child/MRC20.sol",
+      "artifact": "MRC20",
+      "solc": "0.5.17",
+      "borChainId": "15001",
+      "note": "Genesis contract; only changeable via bor hardfork. Embeds ChainIdMixin (via EIP712); deployed CHAINID()=15001 / networkId()=0x3a99 → build with bor-chain-id 15001."
+    },
+    {
+      "chain": "137",
+      "name": "MaticWeth (child, old ChildERC20)",
+      "address": "0x8cc8538d60901d19692F5ba22684732Bc28F54A3",
+      "file": "contracts/child/legacy/ChildERC20Legacy.sol",
+      "artifact": "ChildERC20Legacy",
+      "solc": "0.5.11",
+      "borChainId": "137",
+      "unverified": true,
+      "note": "Auto-deployed by old ChildChain via `new ChildERC20(...)`. Unverified on Polygonscan, but its runtime reproduces from the frozen ChildERC20Legacy (the exact old code ChildChain embeds)."
+    },
+    {
+      "chain": "137",
+      "name": "TestToken (child, old ChildERC20)",
+      "address": "0x5E1DDF2e5a0eCDD923692d4b4429d8603825A8C6",
+      "file": "contracts/child/legacy/ChildERC20Legacy.sol",
+      "artifact": "ChildERC20Legacy",
+      "solc": "0.5.11",
+      "borChainId": "137",
+      "unverified": true,
+      "note": "Auto-deployed by old ChildChain. Reproduces from ChildERC20Legacy (same runtime as MaticWeth child)."
+    },
+    {
+      "chain": "137",
+      "name": "RootERC721 (child, old ChildERC721)",
+      "address": "0xa35363CFf92980F8268299D0132D5f45834A9527",
+      "file": "contracts/child/legacy/ChildERC721Legacy.sol",
+      "artifact": "ChildERC721Legacy",
+      "solc": "0.5.11",
+      "borChainId": "137",
+      "unverified": true,
+      "note": "Auto-deployed by old ChildChain via `new ChildERC721(...)`. Reproduces from the frozen ChildERC721Legacy."
+    },
+    {
+      "chain": "137",
+      "name": "ChildTokenProxy (LORD, proxified ERC721)",
+      "address": "0x1FF58e665531953a3C667E2D831586777fE4Be31",
+      "file": "contracts/child/proxifiedChildToken/ChildTokenProxy.sol",
+      "artifact": "ChildTokenProxy",
+      "solc": "0.5.17",
+      "note": "Immutable proxy shell (UpgradableProxy) for the LORD ERC721, manually mapped. Delegates to an upgradeable ChildERC721Proxified impl (0xd2Cb63…, unverified, deferred). All ChildTokenProxy instances share this runtime."
+    },
+    {
+      "chain": "137",
+      "name": "ChildTokenProxy (DAI, proxified ERC20)",
+      "address": "0x84000b263080BC37D1DD73A29D92794A6CF1564e",
+      "file": "contracts/child/proxifiedChildToken/ChildTokenProxy.sol",
+      "artifact": "ChildTokenProxy",
+      "solc": "0.5.17",
+      "note": "Immutable proxy shell for the current DAI child. Delegates to ChildERC20Proxified impl 0x53a0BB… (unverified, deferred)."
+    },
+    {
+      "chain": "1",
+      "name": "DepositManager (impl)",
+      "address": "0xb00aa68b87256E2F22058fB2Ba3246EEc54A44fc",
+      "file": "contracts/root/depositManager/DepositManager.sol",
+      "artifact": "DepositManager",
+      "solc": "0.5.17",
+      "upgradeable": true,
+      "note": "UPGRADEABLE impl behind DepositManagerProxy. Not an immutable pin — verified informationally (repo should reproduce the current impl). Uses the modern GovernanceLockable/Governable bases."
+    },
+    {
+      "chain": "1",
+      "name": "WithdrawManager (impl)",
+      "address": "0x6F8a42cf6f3CE657B66A9d5849f1251dE7a35168",
+      "file": "contracts/root/withdrawManager/WithdrawManager.sol",
+      "artifact": "WithdrawManager",
+      "solc": "0.5.17",
+      "upgradeable": true,
+      "note": "UPGRADEABLE impl behind WithdrawManagerProxy. This is the impl the proxy points at today; the older 0x31f9… address is stale."
+    },
+    {
+      "chain": "1",
+      "name": "RootChain (impl)",
+      "address": "0x536c55cFe4892E581806e10b38dFE8083551bd03",
+      "file": "contracts/root/RootChain.sol",
+      "artifact": "RootChain",
+      "solc": "0.5.17",
+      "borChainId": "137",
+      "upgradeable": true,
+      "note": "UPGRADEABLE impl behind RootChainProxy (chain-id 137). Reproduces from current source. NOTE: RootChain.sol keeps an empty no-op `function slash() {}` solely to match this deployed impl, which still has it (the slash removal 0c08057a is not yet deployed to RootChain) — that no-op is marked for deletion on the next RootChain redeploy."
+    },
+    {
+      "chain": "1",
+      "name": "Governance (impl)",
+      "address": "0x98165b71cdDea047C0A49413350C40571195fd07",
+      "file": "contracts/common/governance/Governance.sol",
+      "artifact": "Governance",
+      "solc": "0.5.11",
+      "upgradeable": true,
+      "note": "UPGRADEABLE impl behind GovernanceProxy."
+    },
+    {
+      "chain": "1",
+      "name": "ValidatorShare (impl)",
+      "address": "0xBe63B977ABBAA99fC0243e208340c530Dd4ee9E8",
+      "file": "contracts/staking/validatorShare/ValidatorShare.sol",
+      "artifact": "ValidatorShare",
+      "solc": "0.5.17",
+      "upgradeable": true,
+      "note": "UPGRADEABLE impl, current one registered via Registry.getValidatorShareAddress() (all ValidatorShareProxy instances delegate to it); the older 0x053FA9b9… address is stale. Reproduces from current repo source."
+    },
+    {
+      "chain": "1",
+      "name": "StakeManager (impl)",
+      "address": "0x3AD88467E40399dc6Ae10427f8B0842348d9076c",
+      "file": "contracts/staking/stakeManager/StakeManager.sol",
+      "artifact": "StakeManager",
+      "solc": "0.5.17",
+      "upgradeable": true,
+      "note": "UPGRADEABLE impl behind StakeManagerProxy, deployed 2024-10-30, 24212 bytes. Reproduces from current source: main was reverted to this deployed version (built from 5b7e40e5) so the repo mirrors the chain. It was deployed with the 9-argument `initialize` and migrated to POL afterwards by a separate governance `initializePOL` call — the POL-aware initializer was never deployed, so the deploy/test harnesses run that two-step sequence. Delegates to the StakeManagerExtension below, which predates the two POL storage slots; see StakeManagerStorageExtensionLegacy.sol."
+    },
+    {
+      "chain": "1",
+      "name": "StakeManagerExtension (impl)",
+      "address": "0xef49Ea6996073752b6840CDA34773FFA78F78166",
+      "file": "contracts/staking/stakeManager/StakeManagerExtension.sol",
+      "artifact": "StakeManagerExtension",
+      "solc": "0.5.17",
+      "upgradeable": true,
+      "note": "UPGRADEABLE `extensionCode` that the StakeManager delegates to, deployed 2021-03-26 (truffle era), 7653 bytes. Reproduces from current source (built from a1e3e275). It predates the MATIC->POL migration, so it inherits StakeManagerStorageExtensionLegacy (the pre-POL prefix) rather than StakeManagerStorageExtension: because it declares public state, inheriting the two POL slots would emit two extra getters into its runtime and it would no longer reproduce."
+    }
+  ]
+}

--- a/script/pinning/pinned-contracts.json
+++ b/script/pinning/pinned-contracts.json
@@ -376,6 +376,20 @@
         "sig": "extensionCode()(address)"
       },
       "note": "UPGRADEABLE `extensionCode` that the StakeManager delegates to, deployed 2021-03-26 (truffle era), 7653 bytes. Reproduces from current source (built from a1e3e275). It predates the MATIC->POL migration, so it inherits StakeManagerStorageExtensionLegacy (the pre-POL prefix) rather than StakeManagerStorageExtension: because it declares public state, inheriting the two POL slots would emit two extra getters into its runtime and it would no longer reproduce."
+    },
+    {
+      "chain": "1",
+      "name": "EventsHub (impl)",
+      "address": "0x0672777617CAA1E778083a4f74eBC997262C9EdD",
+      "file": "contracts/staking/EventsHub.sol",
+      "artifact": "EventsHub",
+      "solc": "0.5.17",
+      "upgradeable": true,
+      "liveness": {
+        "target": "0x6dF5CB08d3f0193C768C8A01f42ac4424DC5086b",
+        "sig": "implementation()(address)"
+      },
+      "note": "UPGRADEABLE impl behind EventsHubProxy 0x6dF5CB08…. Does not embed ChainIdMixin — verified identical when built at 137 and 15001 — so no borChainId is needed."
     }
   ]
 }

--- a/script/pinning/pinned-contracts.json
+++ b/script/pinning/pinned-contracts.json
@@ -227,7 +227,7 @@
       "file": "contracts/child/proxifiedChildToken/ChildTokenProxy.sol",
       "artifact": "ChildTokenProxy",
       "solc": "0.5.17",
-      "note": "Immutable proxy shell (UpgradableProxy) for the LORD ERC721, manually mapped. Delegates to an upgradeable ChildERC721Proxified impl (0xd2Cb63…, unverified, deferred). All ChildTokenProxy instances share this runtime."
+      "note": "Immutable proxy shell (UpgradableProxy) for the LORD ERC721, manually mapped. Delegates to the upgradeable ChildERC721Proxified impl 0xd2Cb63…, tracked separately below. All ChildTokenProxy instances share this runtime."
     },
     {
       "chain": "137",
@@ -236,7 +236,31 @@
       "file": "contracts/child/proxifiedChildToken/ChildTokenProxy.sol",
       "artifact": "ChildTokenProxy",
       "solc": "0.5.17",
-      "note": "Immutable proxy shell for the current DAI child. Delegates to ChildERC20Proxified impl 0x53a0BB… (unverified, deferred)."
+      "note": "Immutable proxy shell for the current DAI child. Delegates to the ChildERC20Proxified impl 0x53a0BB…, tracked separately below. A superseded DAI shell 0x453b75d2… is also still on-chain but no longer registered (Registry.rootToChildToken(DAI) returns this address), so it is not tracked."
+    },
+    {
+      "chain": "137",
+      "name": "ChildERC20Proxified (DAI impl, current)",
+      "address": "0x53a0BBCcAc4945DDC09819b9686DdFC2295d2616",
+      "file": "contracts/child/proxifiedChildToken/ChildERC20Proxified.sol",
+      "artifact": "ChildERC20Proxified",
+      "solc": "0.5.17",
+      "borChainId": "137",
+      "upgradeable": true,
+      "unverified": true,
+      "note": "UPGRADEABLE impl behind ChildTokenProxy 0x84000b26… (the current DAI child). Unverified on Polygonscan; identified by bytecode. Deployed networkId()=0x89 → bor-chain-id 137. Same source as the deprecated impl 0xa45b96… — the only bytecode difference is the 3-byte ChainIdMixin constant, which is very likely why DAI was redeployed and remapped. Reproduces only with the pre-POL-rename EIP712 domain; see contracts/child/misc/EIP712.sol."
+    },
+    {
+      "chain": "137",
+      "name": "ChildERC721Proxified (LORD impl)",
+      "address": "0xd2Cb630Fd8e56c4a96B9cB3A03Fa6bF96ba4b7Ad",
+      "file": "contracts/child/proxifiedChildToken/ChildERC721Proxified.sol",
+      "artifact": "ChildERC721Proxified",
+      "solc": "0.5.17",
+      "borChainId": "15001",
+      "upgradeable": true,
+      "unverified": true,
+      "note": "UPGRADEABLE impl behind ChildTokenProxy 0x1FF58e66… (LORD). Unverified on Polygonscan; identified by bytecode. Deployed networkId()=0x3a99 → bor-chain-id 15001 — still the Mumbai-era value, unlike the current DAI impl which was moved to 137."
     },
     {
       "chain": "1",

--- a/script/pinning/verify-bytecode.sh
+++ b/script/pinning/verify-bytecode.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Verify that the repo's sources still compile to exactly the bytecode deployed
+# on-chain for every non-upgradeable (pinned) contract in pinned-contracts.json.
+#
+# Usage: script/pinning/verify-bytecode.sh [chainid ...]   (default: all chains)
+#
+# Each contract is compiled with the solc version it was originally deployed
+# with (--use <ver>), into a separate out dir, then its deployedBytecode is
+# compared against `cast code <address>`. See compare_bytecode.py for the
+# comparison levels. Exit code 1 if any contract has a logic-level mismatch.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+CONFIG=script/pinning/pinned-contracts.json
+WORK=verify-onchain
+ISTAKE=contracts/staking/stakeManager/IStakeManager.sol
+mkdir -p "$WORK/build" "$WORK/onchain"
+
+CHAINS=("$@")
+if [ ${#CHAINS[@]} -eq 0 ]; then
+  CHAINS=($(jq -r '.rpc | keys[]' "$CONFIG"))
+fi
+
+# Restore any temporary edits / regenerated templates on exit, no matter what.
+# `process-templates.cjs` globs ALL **/*.template, so rendering ChainIdMixin also
+# rewrites the tracked test-bor-docker/genesis.json (cosmetic reformat) — restore it.
+cleanup() {
+  git checkout -- "$ISTAKE" 2>/dev/null || true
+  node tools/process-templates.cjs >/dev/null 2>&1 || true
+  git checkout -- test-bor-docker/genesis.json 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# The 0.5.11-era proxies (Deposit/WithdrawManagerProxy) reach IStakeManager.sol,
+# which is hard-pinned to `pragma solidity 0.5.17` and refuses to build under
+# 0.5.11. Relax it to the floor pragma for the duration of the run (restored by
+# the trap). This is a build-only concession, not a source change.
+sed -i.bak 's/^pragma solidity 0.5.17;/pragma solidity ^0.5.2;/' "$ISTAKE" && rm -f "$ISTAKE.bak"
+
+# 1. build each contract with its deploy-time solc version AND its pinned
+#    bor-chain-id (ChainIdMixin is per-contract; default 137 for non-consumers).
+#    Auto-detect would float solc to 0.5.17 and the template to its 15001 default.
+: > "$WORK/build-failures.log"
+for cid in $(jq -r '[.contracts[] | select(.exclude != true) | (.borChainId // "137")] | unique | .[]' "$CONFIG"); do
+  echo "==> render ChainIdMixin with bor-chain-id $cid"
+  node tools/process-templates.cjs -c "$cid" >/dev/null
+  for pair in $(jq -r --arg cid "$cid" '[.contracts[] | select(.exclude != true) | select((.borChainId // "137") == $cid) | "\(.solc)|\(.file)"] | unique | .[]' "$CONFIG"); do
+    v=${pair%%|*} f=${pair#*|}
+    echo "==>   forge build --use $v $f"
+    if FOUNDRY_OUT="$WORK/build/out-$v" forge build --use "$v" --force "$f" >/dev/null 2>"$WORK/.builderr"; then
+      # --force cleans the out dir each build, so persist artifacts before the
+      # next iteration wipes them. Key the cache by bor-chain-id as well as solc:
+      # one source file can be deployed at two different chain ids, and without
+      # $cid the later build silently overwrites the earlier one, leaving both
+      # entries compared against the wrong artifact.
+      mkdir -p "$WORK/artifacts/$cid/$v"
+      cp -R "$WORK/build/out-$v/$(basename "$f")" "$WORK/artifacts/$cid/$v/"
+    else
+      echo "BUILD FAILED ($v, chainid $cid): $f" | tee -a "$WORK/build-failures.log"
+      sed -n '1,6p' "$WORK/.builderr"
+    fi
+  done
+done
+
+# 2. fetch on-chain runtime code (cached per address)
+for chain in "${CHAINS[@]}"; do
+  rpc=$(jq -r --arg c "$chain" '.rpc[$c]' "$CONFIG")
+  for addr in $(jq -r --arg c "$chain" '.contracts[] | select(.chain == $c) | select(.exclude != true) | .address' "$CONFIG"); do
+    out="$WORK/onchain/${chain}_$(echo "$addr" | tr 'A-F' 'a-f').hex"
+    if [ ! -s "$out" ]; then
+      echo "==> cast code $addr (chain $chain)"
+      cast code "$addr" --rpc-url "$rpc" > "$out"
+    fi
+  done
+done
+
+# 3. compare
+python3 script/pinning/compare_bytecode.py "$CONFIG" "$WORK" "${CHAINS[@]}"

--- a/script/pinning/verify-bytecode.sh
+++ b/script/pinning/verify-bytecode.sh
@@ -14,7 +14,7 @@ cd "$(dirname "$0")/../.."
 CONFIG=script/pinning/pinned-contracts.json
 WORK=verify-onchain
 ISTAKE=contracts/staking/stakeManager/IStakeManager.sol
-mkdir -p "$WORK/build" "$WORK/onchain"
+mkdir -p "$WORK/build" "$WORK/onchain" "$WORK/liveness"
 
 CHAINS=("$@")
 if [ ${#CHAINS[@]} -eq 0 ]; then
@@ -72,6 +72,24 @@ for chain in "${CHAINS[@]}"; do
       cast code "$addr" --rpc-url "$rpc" > "$out"
     fi
   done
+done
+
+# 2b. resolve liveness pointers. Bytecode at a fixed address is immutable, so comparing it can
+#     never catch the system being re-pointed at a DIFFERENT address — a proxy upgrade or a Registry
+#     re-registration leaves the old address, and this check, perfectly green. That has already
+#     happened once (Registry.erc20Predicate moved 0x626fb210... -> 0x4EeA1780...). So for entries
+#     that are reached through a pointer, ask the live system what it points at now and require it
+#     to still be the address we pin. NOT cached: this is the one value that can change.
+for chain in "${CHAINS[@]}"; do
+  rpc=$(jq -r --arg c "$chain" '.rpc[$c]' "$CONFIG")
+  while IFS='|' read -r addr target sig; do
+    [ -z "$addr" ] && continue
+    out="$WORK/liveness/${chain}_$(echo "$addr" | tr 'A-F' 'a-f').addr"
+    echo "==> cast call $target $sig (chain $chain)"
+    cast call "$target" "$sig" --rpc-url "$rpc" >"$out" 2>/dev/null || echo "CALL_FAILED" >"$out"
+  done < <(jq -r --arg c "$chain" '.contracts[]
+             | select(.chain == $c) | select(.exclude != true) | select(.liveness)
+             | "\(.address)|\(.liveness.target)|\(.liveness.sig)"' "$CONFIG")
 done
 
 # 3. compare

--- a/script/setup/DeploySystem.s.sol
+++ b/script/setup/DeploySystem.s.sol
@@ -124,12 +124,18 @@ contract DeploySystem is Script, ArtifactPath {
                         validatorShareFactory,
                         governanceProxy,
                         owner,
-                        stakeManagerExtension,
-                        address(polToken),
-                        address(polygonMigration)
+                        stakeManagerExtension
                     )
                 )
             );
+
+        // Mainnet was initialized with the 9-argument `initialize` above and then migrated to POL by a
+        // separate governance `initializePOL` call. Reproduce that two-step sequence rather than a
+        // single POL-aware initializer, which has never been deployed.
+        governanceUpdateCall(
+            address(stakeManager),
+            abi.encodeCall(StakeManager.initializePOL, (address(polToken), address(polygonMigration)))
+        );
 
         StakingNFT(stakingNFT).transferOwnership(address(stakeManager));
 

--- a/test/helpers/deployer.js
+++ b/test/helpers/deployer.js
@@ -45,13 +45,19 @@ class Deployer {
         this.validatorShareFactory.address,
         this.governance.address,
         owner,
-        auctionImpl.address,
-        this.polToken.address,
-        this.migration.address
+        auctionImpl.address
       ])
     )
 
     this.stakeManager = contractFactories.StakeManager.attach(stakeManagerProxy.address)
+
+    // Mainnet ran the 9-argument initialize above and then migrated to POL through a separate
+    // governance call. Reproduce that sequence; the POL-aware initializer was never deployed.
+    await this.governance.update(
+      this.stakeManager.address,
+      this.stakeManager.interface.encodeFunctionData('initializePOL', [this.polToken.address, this.migration.address])
+    )
+
     // TODO cannot alter functions like we used to here, replace usage with actual impl like below
     // this.buildStakeManagerObject(this.stakeManager, this.governance)
     await this.governance.update(
@@ -113,12 +119,16 @@ class Deployer {
         this.governance.address,
         wallets[0].getAddressString(),
         auctionImpl.address,
-        this.polToken.address,
-        this.migration.address,
       ])
     )
 
     this.stakeManager = contractFactories.StakeManagerTestable.attach(proxy.address)
+
+    // See deployStakeManager: mainnet initialized with 9 arguments, then migrated to POL separately.
+    await this.governance.update(
+      this.stakeManager.address,
+      this.stakeManager.interface.encodeFunctionData('initializePOL', [this.polToken.address, this.migration.address])
+    )
 
     await this.stakingNFT.transferOwnership(this.stakeManager.address)
     await this.updateContractMap(ethUtils.keccak256('stakeManager'), this.stakeManager.address)

--- a/test/helpers/marketplaceUtils.js.template
+++ b/test/helpers/marketplaceUtils.js.template
@@ -79,8 +79,8 @@ function getTransferTypedData({
       ]
     },
     domain: {
-      name: "Polygon Ecosystem Token",
-      version: "2",
+      name: "Matic Network",
+      version: "1",
       chainId: {{ borChainId }},
       verifyingContract: tokenAddress
     },

--- a/test/units/staking/stakeManager/StakeManager.test.js
+++ b/test/units/staking/stakeManager/StakeManager.test.js
@@ -92,8 +92,6 @@ describe('StakeManager', function (accounts) {
             ZeroAddr,
             ZeroAddr,
             ZeroAddr,
-            ZeroAddr,
-            ZeroAddr,
             ZeroAddr
           ),
           'already inited'


### PR DESCRIPTION
## What this is

#54 pinned the immutable contracts. This finishes the job: it brings the **StakeManager pair** to bytecode equivalence, pins the remaining implementations, and adds the tooling and CI guard that keep it true. After this, **every PoS contract whose source lives in this repo reproduces the exact runtime bytecode deployed on-chain** — 36 contracts across Ethereum mainnet and Polygon PoS.

It replaces the two review drafts #55 and #56, which were not mergeable as-is (below).

This is the source-of-truth shape worth holding: **`main` mirrors the chain; `dev` holds what we intend to deploy next.** Every PR's diff is then its deployment diff, and a reader of `main` is reading production.

## Commits

| | |
|---|---|
| `abc98cc1` | #55 cherry-picked — StakeManager reverted to the deployed implementation (@ethyla) |
| `1b9f0032` | pre-POL extension storage split — the piece that makes #55 + #56 coexist |
| `8e6c3c90` | deploy/test harnesses use the initialization path mainnet actually used |
| `0a81c972` | test fix for the 9-argument initializer |
| `027611eb` | `script/pinning/` — the verifier, the inventory, and README docs |
| `fdeb3c50` | restore the deployed EIP-712 domain |
| `5d932b9e` | pin the proxified child-token implementations |
| `889b637c` | assert pinned addresses are still the ones the live system points at |
| `4b05e9d1` | `.github/workflows/verify-pinning.yml`, main-only |
| `fb78d84a` | separate an unreadable liveness call from real drift |
| `bce7aa30` | pin the EventsHub implementation |

### Why #55 and #56 could not both be merged

The live StakeManager pair straddles the POL storage addition. The deployed StakeManager implementation (`0x3AD88467…`, 2024) carries the `tokenMatic`/`migration` slots; the extension it delegates to (`0xef49Ea69…`, 2021) predates them. Both inherited the same `StakeManagerStorageExtension`, so no single tree could reproduce both — #56 notes that on its branch `StakeManager.sol` deliberately does not compile.

`1b9f003` extracts the pre-POL prefix into `StakeManagerStorageExtensionLegacy` and has `StakeManagerStorageExtension` append the two POL slots to it. The shared prefix is declared once and cannot drift; the extension inherits the Legacy base, the StakeManager keeps the full layout. Both reproduce from one tree, and a real storage-layout difference between two live contracts becomes visible in the source instead of implicit.

### Initialization path

`8e6c3c9` fixes a second divergence the revert exposed. The deployed StakeManager takes a **9-argument** `initialize` and was migrated to POL afterwards by a separate governance `initializePOL` call. `main` folded POL into an **11-argument** initializer that has never been deployed, and both `script/setup/DeploySystem.s.sol` and `test/helpers/deployer.js` followed `main` rather than the chain. They now run the two-step sequence, so local deploys and tests reach the live initialization state.

### EIP-712 domain

`fdeb3c5` is the same class of fix. `contracts/child/misc/EIP712.sol` carried `"Polygon Ecosystem Token"` / `"2"` from the July 2024 POL rename (`c0a3fd7d`, `62fc8652`, `39e006fa`), but **that was never deployed** — every live proxified child-token implementation is `"Matic Network"` / `"1"`. Confirmed cryptographically rather than by string match: recomputing `EIP712_DOMAIN_HASH` over the four candidate name/version pairs reproduces each impl's on-chain value only for `("Matic Network", "1")`. Unpatched source is +16 bytes on both contracts.

The scope is narrow — that file's only consumer chain is `LibTokenTransferOrder` → `ChildToken` → `BaseERC20`/`BaseERC20NoSig` → `ChildERC20`/`ChildERC721`/`MRC20`. Nothing in staking or the root bridge inherits it. `ValidatorShare` and `ERC20Permit` have their own, unrelated domains.

There is an inline warning at the constants, because this is a live trap: **redeploying a child-token implementation from renamed source would silently change its domain separator** and invalidate outstanding `transferWithSig` signatures. The POL rename is deliberately not carried on any branch.

## What the restored StakeManager code does

This revert restores the validator-slot auction (`startAuction`, `confirmAuctionBid`, `dethroneAndStake`, `stopAuctions`) to `main`, because it is present in the deployed implementation at `0x3AD88467…`. Reviewers should know its current state:

- The contract is unlocked (`locked() == false`) and the auction functions are reachable by ABI. A simulated `startAuction` against an active validator passes every check except one.
- That check is `replacementCoolDown == 0 || replacementCoolDown <= currentEpoch` in `StakeManagerExtension`. At the time of writing the live values are `replacementCoolDown = 2018083` against a `currentEpoch` of `108310`, so auctions revert. There is no pending auction state — `validatorAuction[id]` is `amount = 0, user = 0x0` for every validator sampled, and `confirmAuctionBid` reverts.
- That slot has exactly two writers, both `onlyGovernance`: `stopAuctions`, which set the current value, and `updateDynastyValue`, which sets it to `currentEpoch + dynasty/4` — 20 epochs at the present `dynasty = 80`. A dynasty change would therefore re-enable auctions as a side effect unrelated to its stated purpose. Note that `0` also satisfies the guard.

None of this is externally triggerable; enabling it requires a governance transaction. It is recorded here because `main` now reflects deployed behaviour, and this is behaviour `main` previously hid: the pre-#54 `main` had removed the auction and marked `replacementCoolDown` deprecated, so no reader of the repo would have seen it.

## The verifier

`script/pinning/verify-bytecode.sh` builds every inventory entry with its recorded solc and bor-chain-id and compares the metadata-stripped runtime against `eth_getCode`. Requires `forge`, `cast`, `jq`, `python3`. Documented in the README under "Verifying on-chain bytecode".

```
ETH_RPC_URL=… POLYGON_RPC_URL=… script/pinning/verify-bytecode.sh

36 checked: 0 exact, 36 metadata-only diff, 0 problems
```

All 36: `Registry` · `GovernanceProxy` · `Governance (impl)` · `RootChainProxy` · `RootChain (impl)` · `StateSender` · `DepositManagerProxy` · `DepositManager (impl)` · `WithdrawManagerProxy` · `WithdrawManager (impl)` · `ExitNFT` · `PriorityQueue` · `MaticWETH` · `TestToken` · `RootERC721` · `StakeManagerProxy` · `StakeManager (impl)` · `StakeManagerExtension (impl)` · `EventsHubProxy` · `EventsHub (impl)` · `StakingInfo` · `StakingNFT` · `ValidatorShareFactory` · `ValidatorShareProxy (instance)` · `ValidatorShare (impl)` · `ERC20PredicateBurnOnly` · `ERC721PredicateBurnOnly` — and on Polygon PoS: `ChildChain` · `MRC20 (genesis)` · 3 auto-deployed legacy child tokens · 2 `ChildTokenProxy` shells · `ChildERC20Proxified (DAI impl)` · `ChildERC721Proxified (LORD impl)`.

`MATCH_NO_META` rather than `MATCH` is the expected pass: solc appends a CBOR trailer hashing source paths and compiler settings, so it is never reproducible and is stripped from both sides. Everything before it matches byte for byte.

The check is not vacuous — it caught two real things while being built. Run against `feat/stakeManagerCleanup` (which deliberately carries the undeployed cleanup) it reports the StakeManager pair as `MISMATCH` at 21612-vs-24212 and 4680-vs-7653 bytes. And it caught a bug in its own artifact cache: the two `ChildERC20Proxified` impls share a file and solc version but differ in bor-chain-id, and the cache was keyed only on `(solc, filename)`, so the second build silently overwrote the first. Fixed by keying on chain-id too.

Three build inputs are load-bearing, and a plain `forge build` gets them wrong, which is why the inventory records them per contract:

- **solc version per contract.** Auto-detect floats everything to 0.5.17 and the 0.5.11-era contracts silently mismatch.
- **bor-chain-id per contract — it is not global.** `RootChainProxy`, `RootChain`, the new ERC20 predicate, `ChildChain` and its child tokens are **137**; the original 2020 ERC721 predicate and `MRC20` are **15001**. No single template render reproduces all of them.
- `ChildChain` needs solc `0.5.11`; the on-chain bytes encode that version themselves.

The script strips each contract's own CBOR trailer and masks the **nested** trailers carried by embedded creation code — `ChildChain` embeds the child-token constructors, whose source hashes are not reproducible. Everything else is compared byte for byte.

### Pointer liveness

Bytecode at a fixed address is immutable, so comparing bytecode can never catch the system being re-pointed at a **different** address: after a proxy upgrade or a Registry re-registration the old address keeps its code and a bytecode-only check stays green while `main` no longer mirrors what is live. That has already happened once — `Registry.erc20Predicate()` moved from `0x626fb210…` to `0x4EeA1780…`.

So entries reached through a pointer carry a `liveness` spec — a `target` + `sig` call whose returned address must still equal the entry's own `address`. 12 entries have one, and they resolve three different ways, which is why the field is a generic call rather than a hardcoded `implementation()`:

| Shape | Count |
|---|---|
| `proxy.implementation()` | 8 |
| `Registry.getValidatorShareAddress()` / `erc20Predicate()` / `erc721Predicate()` | 3 |
| `StakeManagerProxy.extensionCode()` — a plain storage getter, not a proxy pointer | 1 |

Drift is reported as `STALE_POINTER` naming the address now returned. An unreadable call is reported separately as `POINTER_UNRESOLVED`, so a flaky RPC is never mistaken for a real proxy upgrade — or, more importantly, a real upgrade dismissed as flakiness.

## CI

`.github/workflows/verify-pinning.yml` runs on push and PR to `main`, plus manual dispatch. Deliberately **not** on `dev`: `dev` holds what we intend to deploy next and is *expected* to diverge, so a pinning job there would be permanently red by design. On failure it uploads `results.json` and `diffs/*.hex`, which are otherwise gitignored and the only way to see *where* bytecode diverged.

Only `MATCH` and `MATCH_NO_META` pass. Every other status exits non-zero, and each path was tested individually: `MISMATCH`, `STALE_POINTER`, `POINTER_UNRESOLVED`, `NO_CODE`, `MISSING_ARTIFACT`, and verifying zero contracts (a typo'd chain filter) — which is an error rather than a clean run, since it is the one way the script could lie.

No schedule. Bytecode at a fixed address never changes, so re-fetching on a timer proves nothing; the liveness check *would* catch a re-pointing without a commit, so a periodic run is worth adding later if wanted.

## Verification

- `forge build --sizes` clean, `forge test` 51/51
- Hardhat `npm run test:ci` (anvil + bor) **1583 passing / 12 pending / 0 failing**
- `script/pinning/verify-bytecode.sh` **36/36, 0 problems**, all 12 liveness pointers as expected

## Not covered

- **Out-of-repo deployments**: the POL suite (`PolygonEcosystemToken`, `PolygonMigration`, `DefaultEmissionManager` + proxies), the L1 `Timelock`, L1 `MaticToken`, `WMATIC`, and `EIP1559Burn` on both chains. They belong to other repos and should be pinned there.
- **`SlashingManager`** `0x01F645Dc…` is deployed but its source was deleted from this repo (`0c08057a`), so it cannot be built here at all. Open question: restore a frozen copy so it is verifiable, or document it as permanently unverifiable.
- **Superseded deployments** that are still on-chain but no longer registered — the old ERC20 predicate `0x626fb210…` and the previous DAI child shell `0x453b75d2…` with its implementation. Dead mappings, so pinning them buys nothing; `docs/analysis/plasma-child-token-map.md` in the tools repo records how to re-derive them.
- **Testnets.** The inventory is mainnet-only on purpose. The intent is to bring Sepolia/Amoy up to mainnet's code rather than make this tree satisfy two divergent networks at once.
- `DrainStakeManager` is in the repo but in no address book, so there is nothing to pin.

## Follow-ups

1. Make `verify-pinning` a **required check** on `main` — without branch protection it is advisory.
2. Reopen the StakeManager cleanup as explicit PRs against `dev`, one change per PR, so each is reviewed on its own merit against a baseline that matches the chain.
3. Rebase #53 onto `dev` and state its deployment scope against the deployed baseline rather than against the current `main`. Note that the ValidatorPass hook does **not** fit on the deployed StakeManager: it exceeds EIP-170 by 194 bytes, because the deployed implementation has only 312 bytes of headroom and the hook costs 506. It is therefore coupled to the cleanup landing first.
4. Point `pos-contracts-v2`'s `legacy.toml` at `dev`, or its ValidatorPass tests will build an un-gated StakeManager once this lands.
5. The inventory is maintained by hand; nothing yet detects a *newly deployed* contract that should have been pinned.

The StakeManager revert here is @ethyla's work from #55; this branch adds the storage split that makes it mergeable, the harness and EIP-712 fixes, the verifier, and the CI guard that keeps it honest.
