### PR TITLE
Optional validator-entry permissioning via ValidatorPass

### DIFF
--- a/contracts/staking/stakeManager/IValidatorPass.sol
+++ b/contracts/staking/stakeManager/IValidatorPass.sol
@@ -6,9 +6,15 @@ pragma solidity 0.5.17;
 interface IValidatorPass {
     /// @notice Consume a validator's single-use pass on entry. Governance authorizes by issuing the
     ///         pass; this consumes it. State-changing, so implementations MUST restrict it to the
-    ///         StakeManager.
+    ///         StakeManager. This call is the frozen boundary of the pass system (widening it later
+    ///         requires a StakeManager upgrade), so it forwards the full entry context; modules are
+    ///         free to ignore what their policy does not need.
     /// @param validator Prospective validator (the `user` of `stakeFor`).
     /// @param signerPubkey Consensus key supplied to `stakeFor`.
+    /// @param amount Stake amount the entrant is joining with (excludes the heimdall fee).
+    /// @param funder `msg.sender` of the stake call — the account paying (third-party entry allowed).
     /// @return consumed True if a valid pass was consumed (entry permitted); false otherwise.
-    function consumePass(address validator, bytes calldata signerPubkey) external returns (bool consumed);
+    function consumePass(address validator, bytes calldata signerPubkey, uint256 amount, address funder)
+        external
+        returns (bool consumed);
 }

--- a/contracts/staking/stakeManager/IValidatorPass.sol
+++ b/contracts/staking/stakeManager/IValidatorPass.sol
@@ -1,0 +1,14 @@
+pragma solidity 0.5.17;
+
+/// @title IValidatorPass
+/// @notice Hook the StakeManager calls to permission validator entry, resolved from the Registry
+///         under `keccak256("validatorPass")` (unset => permissionless).
+interface IValidatorPass {
+    /// @notice Consume a validator's single-use pass on entry. Governance authorizes by issuing the
+    ///         pass; this consumes it. State-changing, so implementations MUST restrict it to the
+    ///         StakeManager.
+    /// @param validator Prospective validator (the `user` of `stakeFor`).
+    /// @param signerPubkey Consensus key supplied to `stakeFor`.
+    /// @return consumed True if a valid pass was consumed (entry permitted); false otherwise.
+    function consumePass(address validator, bytes calldata signerPubkey) external returns (bool consumed);
+}

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -15,6 +15,8 @@ import {StakeManagerStorage} from "./StakeManagerStorage.sol";
 import {StakeManagerStorageExtension} from "./StakeManagerStorageExtension.sol";
 import {Initializable} from "../../common/mixin/Initializable.sol";
 import {StakeManagerExtension} from "./StakeManagerExtension.sol";
+import {Registry} from "../../common/Registry.sol";
+import {IValidatorPass} from "./IValidatorPass.sol";
 
 contract StakeManager is
     StakeManagerStorage,
@@ -25,6 +27,9 @@ contract StakeManager is
 {
     using SafeMath for uint256;
     using Merkle for bytes32;
+
+    // Registry key of the optional validator-pass module that permissions new validator entry.
+    bytes32 constant VALIDATOR_PASS_KEY = keccak256("validatorPass");
 
     struct UnsignedValidatorsContext {
         uint256 unsignedValidatorIndex;
@@ -336,6 +341,14 @@ contract StakeManager is
     function _stakeFor(address user, uint256 amount, uint256 heimdallFee, bool acceptDelegation, bytes memory signerPubkey, bool pol) internal {
         require(currentValidatorSetSize() < validatorThreshold, "no more slots");
         require(amount >= minDeposit, "not enough deposit");
+
+        // Permissioned entry: a registered validator-pass module must consume a single-use pass for
+        // the entrant (issued by governance) before funds move; unregistered => permissionless.
+        address validatorPass = Registry(registry).contractMap(VALIDATOR_PASS_KEY);
+        if (validatorPass != address(0)) {
+            require(IValidatorPass(validatorPass).consumePass(user, signerPubkey), "no valid pass");
+        }
+
         _transferAndTopUp(user, msg.sender, heimdallFee, amount, pol);
         _stakeFor(user, amount, acceptDelegation, signerPubkey);
     }

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -346,7 +346,10 @@ contract StakeManager is
         // the entrant (issued by governance) before funds move; unregistered => permissionless.
         address validatorPass = Registry(registry).contractMap(VALIDATOR_PASS_KEY);
         if (validatorPass != address(0)) {
-            require(IValidatorPass(validatorPass).consumePass(user, signerPubkey), "no valid pass");
+            require(
+                IValidatorPass(validatorPass).consumePass(user, signerPubkey, amount, msg.sender),
+                "no valid pass"
+            );
         }
 
         _transferAndTopUp(user, msg.sender, heimdallFee, amount, pol);


### PR DESCRIPTION
Promotes the work reviewed in #52. `StakeManager` resolves a pass module from the Registry under `keccak256("validatorPass")`; unset means validator entry stays permissionless, and when configured it consumes a single-use pass before funds move.

**Why this targets the cleanup branch rather than `dev`:** it does not fit on the deployed baseline. The hook costs 506 bytes and the deployed implementation has only 312 free, so `forge build --sizes` exits 1. It needs the headroom that #59 frees.

| base | StakeManager | margin to 24,576 |
|---|---|---|
| deployed baseline | 24,770 | **−194 — build fails** |
| on the cleanup branch | **21,542** | **3,034** |

**A second reason to stack it here.** On the deployed baseline the auction path is a hole: `dethroneAndStake` creates a validator by calling the private 4-argument `_stakeFor` directly, bypassing the pass check entirely. With the auction removed, the hook covers every entry path into the validator set.

Rebased onto the cleanup branch after #64 (initializer removal) merged; the figures above are against that base.

`forge test` 51/51.

