### PR TITLE
Heimdall fee credited to the wrong recipient on stake

### DIFF
--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -464,7 +464,16 @@ contract StakeManager is
     function _stakeFor(address user, uint256 amount, uint256 heimdallFee, bool acceptDelegation, bytes memory signerPubkey, bool pol) internal {
         require(currentValidatorSetSize() < validatorThreshold, "no more slots");
         require(amount >= minDeposit, "not enough deposit");
-        _transferAndTopUp(user, msg.sender, heimdallFee, amount, pol);
+        // The heimdall fee has to be credited to the SIGNER, not to the NFT owner: the signer is the
+        // address that spends it on heimdall fees. `_transferAndTopUp` only uses this argument for
+        // `logTopUpFee`, which is what heimdall reads to credit the balance, so passing `user` here
+        // books every onboarding fee against the wrong account.
+        //
+        // ILLUSTRATIVE ONLY: deriving the signer here repeats the derivation in the private
+        // `_stakeFor` below (an extra keccak plus an SLOAD). It is deliberately ugly to show where
+        // the accounting goes wrong — the real fix is to resolve the signer once and thread it
+        // through, or to emit the event after the signer is known.
+        _transferAndTopUp(_getAndAssertSigner(signerPubkey), msg.sender, heimdallFee, amount, pol);
         _stakeFor(user, amount, acceptDelegation, signerPubkey);
     }
 


### PR DESCRIPTION
**Heimdall fees are credited to the wrong recipient on stake.**

`_stakeFor` books the onboarding fee against `user` (the NFT owner) instead of the signer. `_transferAndTopUp` moves the tokens to the contract either way — the argument only feeds `logTopUpFee`, which is what heimdall reads to credit the fee balance. So the signer, who actually spends it, is never credited: every onboarding wastes the initial fee (~1–5 POL) and needs a second tx to top the signer up.

`topUpForFee()` is fine — there the caller names the beneficiary deliberately. Only the onboarding path is wrong.

**Draft, illustrative only.** The one-line change derives the signer a second time (the private `_stakeFor` already does it), which is deliberately ugly: it shows where the accounting goes wrong without restructuring. A real fix resolves the signer once and threads it through, or emits the event after the signer is known — and needs an end-to-end onboarding test plus confirmation of how heimdall consumes `TopUpFee`.

Targets `dev` directly, since the bug is independent of the StakeManager cleanup stack (#59 / #61) and applies to the currently deployed code.

**Watch the size budget.** The deployed implementation has only 312 bytes of EIP-170 headroom, and the duplicate derivation eats 8 of them:

| | StakeManager | margin to 24,576 |
|---|---|---|
| `dev` | 24,264 | 312 |
| this PR | **24,272** | **304** |

That is a further argument for resolving the signer once rather than shipping this shape — and for landing #59 first if this ever stops being illustrative, since that restores ~2.9 KB of headroom.

Ref `HARDENING_PLAN.md` §3.7a.
