### PR TITLE
Resolve the validator pass from storage instead of the Registry

### DIFF
--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -19,7 +19,6 @@ import {IGovernance} from "../../common/governance/IGovernance.sol";
 import {Initializable} from "../../common/mixin/Initializable.sol";
 import {StakeManagerExtension} from "./StakeManagerExtension.sol";
 import {IPolygonMigration} from "../../common/misc/IPolygonMigration.sol";
-import {Registry} from "../../common/Registry.sol";
 import {IValidatorPass} from "./IValidatorPass.sol";
 
 contract StakeManager is
@@ -31,9 +30,6 @@ contract StakeManager is
 {
     using SafeMath for uint256;
     using Merkle for bytes32;
-
-    // Registry key of the optional validator-pass module that permissions new validator entry.
-    bytes32 constant VALIDATOR_PASS_KEY = keccak256("validatorPass");
 
     struct UnsignedValidatorsContext {
         uint256 unsignedValidatorIndex;
@@ -110,6 +106,15 @@ contract StakeManager is
         NFTCounter = 1;
         proposerBonus = 10; // 10 % of total rewards
         delegationEnabled = true;
+    }
+
+    /**
+        @dev Points validator entry at a permissioning module, or disables it by passing zero.
+        Governance-only. Called after an upgrade to populate the appended slot; the module can be
+        swapped or removed later through the same function.
+     */
+    function reinitializeValidatorPass(IValidatorPass _validatorPass) external onlyGovernance {
+        validatorPass = _validatorPass;
     }
 
     function isOwner() public view returns (bool) {
@@ -383,14 +388,11 @@ contract StakeManager is
         require(currentValidatorSetSize() < validatorThreshold, "no more slots");
         require(amount >= minDeposit, "not enough deposit");
 
-        // Permissioned entry: a registered validator-pass module must consume a single-use pass for
-        // the entrant (issued by governance) before funds move; unregistered => permissionless.
-        address validatorPass = Registry(registry).contractMap(VALIDATOR_PASS_KEY);
-        if (validatorPass != address(0)) {
-            require(
-                IValidatorPass(validatorPass).consumePass(user, signerPubkey, amount, msg.sender),
-                "no valid pass"
-            );
+        // Permissioned entry: when a pass module is configured it must consume a single-use pass
+        // for the entrant (issued by governance) before funds move; unset => permissionless.
+        IValidatorPass _validatorPass = validatorPass;
+        if (_validatorPass != IValidatorPass(0)) {
+            require(_validatorPass.consumePass(user, signerPubkey, amount, msg.sender), "no valid pass");
         }
 
         _transferAndTopUp(user, msg.sender, heimdallFee, amount, pol);

--- a/contracts/staking/stakeManager/StakeManagerStorageExtension.sol
+++ b/contracts/staking/stakeManager/StakeManagerStorageExtension.sol
@@ -2,6 +2,7 @@ pragma solidity 0.5.17;
 
 import {IPolygonMigration} from "../../common/misc/IPolygonMigration.sol";
 import {IERC20} from "../../common/oz/token/ERC20/IERC20.sol";
+import {IValidatorPass} from "./IValidatorPass.sol";
 
 contract StakeManagerStorageExtension {
     address public eventsHub;
@@ -20,4 +21,6 @@ contract StakeManagerStorageExtension {
 
     IERC20 public tokenMatic;
     IPolygonMigration public migration;
+
+    IValidatorPass public validatorPass;
 }


### PR DESCRIPTION
Resolves the validator-pass module from a storage slot on `StakeManager` instead of a `Registry` lookup. Alternative to how #60 does it; same behaviour, different plumbing.

- `validatorPass` **appended** to `StakeManagerStorageExtension` (slot 45). Verified append-only: all 46 pre-existing variables keep slot *and* byte offset.
- `reinitializeValidatorPass(IValidatorPass)`, `onlyGovernance`, sits directly under `initialize` — populates the slot after upgrade, and can swap or zero the module later, so it keeps the reconfigurability the Registry path had.
- `VALIDATOR_PASS_KEY` and the `Registry` import are gone.

## Why

**We have too many ways to load an address, and should converge on one.** In the StakeManager alone, reachable addresses arrive by at least three different mechanisms today: 9 initializer-set storage pointers (`logger`, `NFTContract`, `validatorShareFactory`, `token`, `tokenMatic`, `migration`, `registry`, `extensionCode`, `eventsHub`), 3 keyed `Registry.contractMap(keccak256(...))` lookups, and 6 bespoke `Registry` getters (`getValidatorShareAddress`, `getSlashingManagerAddress`, …). `eventsHub` is a fourth shape — resolved from the Registry once, then cached into a storage pointer. Adding a fifth consumer of the keyed-lookup pattern for the pass module pushes in the wrong direction; the storage pointer is the pattern the contract already uses most.

**And Registry usage in particular is worth reducing:**

1. **It is on a very old compiler** — `pragma solidity ^0.5.2`, deployed with solc 0.5.11.
2. **It is not upgradeable.** Single immutable deployment at `0x33a02E6cC863D393d6Bf231B697b82F6e499cA71`, no proxy in front of it. Whatever it does today, it does forever.
3. **It is already too critical**, and (1) and (2) are exactly why that matters: every new dependency widens the blast radius of a contract we cannot fix or recompile.

Routing new features through it adds load-bearing weight to the least changeable contract in the system.

## Cost

| | StakeManager | margin |
|---|---|---|
| #60 (Registry lookup) | 22,170 | 2,406 |
| this PR (storage slot) | **22,176** | **2,400** |

+6 bytes of code; at runtime one `SLOAD` replaces an external call into Registry plus its own storage read. Effectively a wash on size, cheaper per stake.

## Trade-off

The pass module is no longer discoverable through the Registry the way other system contracts are, and pointing it somewhere new needs this contract's setter rather than `Registry.updateContractMap`. That is the deliberate choice: an explicit pointer in our own storage and ABI, instead of a key in an immutable contract compiled with solc 0.5.11.

`forge test` 51/51. No test changes — behaviour is unchanged, so #60's coverage applies as-is.
