### PR TITLE
fix: credit the heimdall fee to the signer on stake

### DIFF
--- a/contracts/staking/StakingInfo.sol
+++ b/contracts/staking/StakingInfo.sol
@@ -377,8 +377,8 @@ contract StakingInfo is Ownable {
         emit ConfirmAuction(newValidatorId, oldValidatorId, amount);
     }
 
-    function logTopUpFee(address user, uint256 fee) public onlyStakeManager {
-        emit TopUpFee(user, fee);
+    function logTopUpFee(address feeBeneficiary, uint256 fee) public onlyStakeManager {
+        emit TopUpFee(feeBeneficiary, fee);
     }
 
     function logClaimFee(address user, uint256 fee) public onlyStakeManager {

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -352,8 +352,12 @@ contract StakeManager is
             );
         }
 
-        _transferAndTopUp(user, msg.sender, heimdallFee, amount, pol);
-        _stakeFor(user, amount, acceptDelegation, signerPubkey);
+        // The heimdall fee has to be credited to the SIGNER, not to the NFT owner: the signer is
+        // the address that spends it on heimdall tx fees, and `_transferAndTopUp` uses this argument
+        // only for `logTopUpFee`, which is what heimdall reads to credit the balance.
+        address signer = _getAndAssertSigner(signerPubkey);
+        _transferAndTopUp(signer, msg.sender, heimdallFee, amount, pol);
+        _stakeFor(user, amount, acceptDelegation, signerPubkey, signer);
     }
 
     function unstakeClaim(uint256 validatorId) public onlyStaker(validatorId) {
@@ -908,9 +912,9 @@ contract StakeManager is
         address user,
         uint256 amount,
         bool acceptDelegation,
-        bytes memory signerPubkey
+        bytes memory signerPubkey,
+        address signer
     ) internal returns (uint256) {
-        address signer = _getAndAssertSigner(signerPubkey);
         uint256 _currentEpoch = currentEpoch;
         uint256 validatorId = NFTCounter;
         StakingInfo _logger = logger;

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -1013,11 +1013,11 @@ contract StakeManager is
         if (!pol && destination == address(this)) _convertMaticToPOL(amount);
     }
 
-    function _transferAndTopUp(address user, address from, uint256 fee, uint256 additionalAmount, bool pol) private {
+    function _transferAndTopUp(address feeBeneficiary, address from, uint256 fee, uint256 additionalAmount, bool pol) private {
         require(fee >= minHeimdallFee, "fee too small");
         _transferTokenFrom(from, address(this), fee.add(additionalAmount), pol);
         totalHeimdallFee = totalHeimdallFee.add(fee);
-        logger.logTopUpFee(user, fee);
+        logger.logTopUpFee(feeBeneficiary, fee);
     }
 
     function _insertSigner(address newSigner) internal {

--- a/test/units/staking/stakeManager/StakeManager.Staking.js
+++ b/test/units/staking/stakeManager/StakeManager.Staking.js
@@ -345,6 +345,58 @@ describe('stake', function () {
       await expectRevert(doStake(wallets[3], { signer: AliceWallet.getPublicKeyString() }).call(this), 'Invalid signer')
     })
   })
+
+  describe('stake with separate signer', function () {
+    const owner = wallets[1]
+    const signerWallet = wallets[2]
+    const stakeAmount = web3.utils.toWei('150')
+    const fee = web3.utils.toWei('5')
+
+    before(async function () {
+      await freshDeploy.call(this)
+    })
+
+    before('Approve', async function () {
+      const stakeTokenOwner = this.stakeToken.connect(this.stakeToken.provider.getSigner(owner.getAddressString()))
+      await stakeTokenOwner.approve(this.stakeManager.address, new BN(stakeAmount).add(new BN(fee)).toString())
+    })
+
+    it('must stake', async function () {
+      const stakeManagerOwner = this.stakeManager.connect(
+        this.stakeManager.provider.getSigner(owner.getAddressString())
+      )
+      this.receipt = await (
+        await stakeManagerOwner.stakeFor(
+          owner.getChecksumAddressString(),
+          stakeAmount,
+          fee,
+          false,
+          signerWallet.getPublicKeyString()
+        )
+      ).wait()
+    })
+
+    it('must credit the heimdall fee to the signer', async function () {
+      utils.assertInTransaction(this.receipt, StakingInfo, 'TopUpFee', {
+        user: signerWallet.getChecksumAddressString(),
+        fee: fee
+      })
+    })
+
+    it('must emit Staked with the signer', async function () {
+      utils.assertInTransaction(this.receipt, StakingInfo, 'Staked', {
+        signerPubkey: signerWallet.getPublicKeyString(),
+        signer: signerWallet.getChecksumAddressString(),
+        amount: stakeAmount
+      })
+    })
+
+    it('must mint the NFT to the owner', async function () {
+      const validatorId = await this.stakeManager.getValidatorId(owner.getChecksumAddressString())
+      const nftOwner = await this.stakeManager.ownerOf(validatorId)
+      assert.equal(nftOwner.toLowerCase(), owner.getAddressString().toLowerCase())
+    })
+  })
 })
 
 describe('unstake', function () {

--- a/test/units/staking/stakeManager/StakeManager.StakingPol.js
+++ b/test/units/staking/stakeManager/StakeManager.StakingPol.js
@@ -346,6 +346,58 @@ describe('stake POL', function () {
       await expectRevert(doStake(wallets[3], { signer: AliceWallet.getPublicKeyString() }).call(this), 'Invalid signer')
     })
   })
+
+  describe('stake with separate signer', function () {
+    const owner = wallets[1]
+    const signerWallet = wallets[2]
+    const stakeAmount = web3.utils.toWei('150')
+    const fee = web3.utils.toWei('5')
+
+    before('deploy', async function () {
+      await freshDeploy.call(this)
+    })
+
+    before('Approve', async function () {
+      const polTokenOwner = this.polToken.connect(this.polToken.provider.getSigner(owner.getAddressString()))
+      await polTokenOwner.approve(this.stakeManager.address, new BN(stakeAmount).add(new BN(fee)).toString())
+    })
+
+    it('must stake', async function () {
+      const stakeManagerOwner = this.stakeManager.connect(
+        this.stakeManager.provider.getSigner(owner.getAddressString())
+      )
+      this.receipt = await (
+        await stakeManagerOwner.stakeForPOL(
+          owner.getChecksumAddressString(),
+          stakeAmount,
+          fee,
+          false,
+          signerWallet.getPublicKeyString()
+        )
+      ).wait()
+    })
+
+    it('must credit the heimdall fee to the signer', async function () {
+      utils.assertInTransaction(this.receipt, StakingInfo, 'TopUpFee', {
+        user: signerWallet.getChecksumAddressString(),
+        fee: fee
+      })
+    })
+
+    it('must emit Staked with the signer', async function () {
+      utils.assertInTransaction(this.receipt, StakingInfo, 'Staked', {
+        signerPubkey: signerWallet.getPublicKeyString(),
+        signer: signerWallet.getChecksumAddressString(),
+        amount: stakeAmount
+      })
+    })
+
+    it('must mint the NFT to the owner', async function () {
+      const validatorId = await this.stakeManager.getValidatorId(owner.getChecksumAddressString())
+      const nftOwner = await this.stakeManager.ownerOf(validatorId)
+      assert.equal(nftOwner.toLowerCase(), owner.getAddressString().toLowerCase())
+    })
+  })
 })
 
 describe('unstake POL', function () {


### PR DESCRIPTION
`_stakeFor` books the onboarding fee against `user` (the NFT owner) instead of the signer. `_transferAndTopUp` uses that argument only for `logTopUpFee`, which is what heimdall reads to credit the fee balance — so every onboarding books the initial fee against an account that never signs heimdall transactions. Heimdall debits tx fees from the tx's first signer and retries validator-join until the signer's fee account exists, so today operators must send a second `topUpForFee(signer, …)` tx and the onboarding fee is wasted.

The fix resolves the signer once and threads it through `_transferAndTopUp` and the private `_stakeFor` (which derived it itself before). Since #59 removed `dethroneAndStake`, the private `_stakeFor` has exactly one caller, so there is no duplicate derivation and no second fee path to fix. `topUpForFee` is unchanged — there the caller names the beneficiary deliberately.

Nothing else changes: same event ordering (`TopUpFee` before `Staked`), tokens are still pulled from `msg.sender`, no storage changes. Stakes where owner == signer are observably unchanged.

Verified against heimdall-v2: `PostHandleTopupTx` (`x/topup/keeper/side_msg_server.go`) credits exactly the address in the event with no membership check, and the bridge's top-up fast path (`event.User == node address`, zero-delay broadcast by the entrant's own node) now matches at onboarding.

Supersedes the illustrative draft #62.

**Size** (forge, solc 0.5.17, optimizer runs 200):

| | StakeManager | margin to 24,576 |
|---|---|---|
| `dev` | 21,542 | 3,034 |
| this PR | 21,541 | 3,035 |

**Tests**: new regression case in both the MATIC and POL staking suites — stakes with owner != signer and asserts `TopUpFee.user == signer`, `Staked.signer == signer`, and that the NFT goes to the owner. The fee assertions fail on unfixed code; with the fix both staking suites are green (185 passing).

Mainnet delivery rides with the next StakeManager impl upgrade (timelock governance) together with the #59/#60 cleanup stack; `pinned-contracts.json` gets updated after that deployment.
