### PR TITLE
Restore the proxy implementation after the initialize test

### DIFF
--- a/test/units/staking/stakeManager/StakeManager.test.js
+++ b/test/units/staking/stakeManager/StakeManager.test.js
@@ -97,6 +97,10 @@ describe('StakeManager', function (accounts) {
         StakeManagerTestInit.attach(this.stakeManager.address).initialize(...new Array(10).fill(ZeroAddr)),
         'already inited'
       )
+
+      // Point the proxy back at the implementation under test so any test that later shares this
+      // deployment does not run against StakeManagerTestInit.
+      await proxy.updateImplementation(deployedImpl)
     })
   })
 


### PR DESCRIPTION
The initialize test points the proxy at `StakeManagerTestInit` to check the `already inited` guard, but it never pointed it back, so the `deployedImpl` it reads was left unused. Harmless today because it is the only test in the block, but anything added to that describe later would silently run against `StakeManagerTestInit` instead of the implementation under test.

This adds the missing `updateImplementation(deployedImpl)` after the revert assertion. Ran the test locally against anvil, passes.