### PR TITLE
Restore the genesis auctionPeriod in StakeManagerTestInit

### DIFF
--- a/contracts/test/StakeManagerTestInit.sol
+++ b/contracts/test/StakeManagerTestInit.sol
@@ -22,8 +22,10 @@ import {StakeManager} from "../staking/stakeManager/StakeManager.sol";
 // Everything after step 3 exercises the implementation under test, which never carries an
 // initializer of its own.
 //
-// This body is now the only description of the genesis state. It must keep matching what the live
-// proxy's storage holds, not whatever a test finds convenient.
+// This body is now the only description of the genesis state. It must keep matching what the
+// genesis initializer wrote, not whatever a test finds convenient. Note that slots governance
+// changed after genesis (e.g. currentEpoch, auctionPeriod, replacementCoolDown) hold their 2020
+// values here, not what the live proxy reads today.
 //
 // The initializer machinery lives entirely here: the constructor burns `inited` on this
 // implementation, so it can only be initialized through a proxy. StakeManager's own constructor
@@ -67,6 +69,7 @@ contract StakeManagerTestInit is StakeManager {
 
         validatorThreshold = 7; //128
         NFTCounter = 1;
+        auctionPeriod = (2**13) / 4; // 1 week in epochs
         proposerBonus = 10; // 10 % of total rewards
         delegationEnabled = true;
     }


### PR DESCRIPTION
`StakeManagerTestInit` claims to re-add the genesis initializer verbatim, but it dropped the `auctionPeriod = (2**13) / 4` line the original wrote. Since this file is now the only description of the genesis state, this restores the line and adjusts the header comment: the body matches what the genesis initializer wrote, and slots that governance changed later (`currentEpoch`, `auctionPeriod`, `replacementCoolDown`) hold their 2020 values, not what the live proxy reads today.

No functional impact, nothing reads these slots after #66. Compiles and the initialize test passes locally.